### PR TITLE
Add @node-dlc/logger

### DIFF
--- a/packages/logger/__tests__/logger.spec.ts
+++ b/packages/logger/__tests__/logger.spec.ts
@@ -1,0 +1,136 @@
+// tslint:disable: no-unused-expression
+import { expect } from "chai";
+import sinon from "sinon";
+import { LogLevel } from "../lib/log-level";
+import { Logger } from "../lib/logger";
+import { ITransport } from "../lib/transport";
+
+describe("Logger", () => {
+    let transport: ITransport;
+    let sut: Logger;
+
+    beforeEach(() => {
+        transport = { write: sinon.stub() };
+        sut = new Logger();
+        sut.transports.push(transport);
+    });
+
+    it("should default log level of Info", () => {
+        expect(sut.level).to.equal(LogLevel.Info);
+    });
+
+    it("should ignore messages below setting", () => {
+        const logger = sut.sub("area");
+        expect((transport.write as sinon.SinonSpy).callCount).to.equal(0);
+        logger.debug("testing");
+        expect((transport.write as sinon.SinonSpy).callCount).to.equal(0);
+    });
+
+    describe("create logger with instance", () => {
+        it("should create logger with instance", () => {
+            const logger = sut.sub("area", "instance");
+            expect(logger.area).to.equal("area");
+            expect(logger.instance).to.equal("instance");
+        });
+
+        it("should write a message to the transport", () => {
+            const logger = sut.sub("area", "instance");
+            logger.info("testing");
+            expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(
+                /\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ \[INF\] area instance: testing/,
+            );
+        });
+    });
+
+    describe("nested sub logger", () => {
+        it("should point to root", () => {
+            sut.level = LogLevel.Debug;
+            const level2 = sut.sub("level2");
+            const level3 = sut.sub("level3");
+            level3.debug("test");
+            expect((transport.write as sinon.SinonSpy).args[0][0]).contain("test");
+        });
+    });
+
+    describe("create logger without instance", () => {
+        it("should create logger without an instance", () => {
+            const logger = sut.sub("area");
+            expect(logger.area).to.equal("area");
+            expect(logger.instance).to.be.undefined;
+        });
+
+        it("should write a message to the transport", () => {
+            const logger = sut.sub("area");
+            logger.info("testing");
+            expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(
+                /\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ \[INF\] area: testing/,
+            );
+        });
+    });
+
+    const fixtures = [
+        { fn: "trace", level: LogLevel.Trace },
+        { fn: "debug", level: LogLevel.Debug },
+        { fn: "info", level: LogLevel.Info },
+        { fn: "warn", level: LogLevel.Warn },
+        { fn: "error", level: LogLevel.Error },
+        { fn: "log", level: LogLevel.Log },
+    ];
+
+    for (const { fn, level } of fixtures) {
+        describe("." + fn, () => {
+            beforeEach(() => {
+                sut = new Logger("area", "instance");
+                sut.level = LogLevel.Trace;
+                sut.transports.push(transport);
+            });
+
+            it("should have message with level " + level, () => {
+                sut[fn]("testing");
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(
+                    new RegExp("[" + level + "]"),
+                );
+            });
+
+            it("should have message with area", () => {
+                sut[fn]("testing");
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(/ area/);
+            });
+
+            it("should have message with instance", () => {
+                sut[fn]("testing");
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(/ instance/);
+            });
+
+            it("should have message with actual message", () => {
+                sut[fn]("testing");
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(/ testing$/);
+            });
+
+            it("should call write with single variable message", () => {
+                sut[fn](5);
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(/5$/);
+            });
+
+            it("should call write with sprintf message", () => {
+                sut[fn]("testing %s, %d, %j", "hello", 5, { foo: "bar" });
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.contain(
+                    'testing hello, 5, {"foo":"bar"}',
+                );
+            });
+
+            it("should call write with variadic message", () => {
+                sut[fn]("testing", 1, 2, 3, 4, "5");
+                expect((transport.write as sinon.SinonSpy).args[0][0]).to.contain(
+                    "testing 1 2 3 4 5",
+                );
+            });
+
+            it("should work unbounded", () => {
+                const debug = sut[fn];
+                debug("testing");
+                expect((transport.write as sinon.SinonSpy).called).to.be.true;
+            });
+        });
+    }
+});

--- a/packages/logger/lib/index.ts
+++ b/packages/logger/lib/index.ts
@@ -1,0 +1,3 @@
+export * from "./logger";
+export * from "./log-level";
+export * from "./transports/console-transport";

--- a/packages/logger/lib/log-level.ts
+++ b/packages/logger/lib/log-level.ts
@@ -1,0 +1,11 @@
+/**
+ * Log level
+ */
+ export enum LogLevel {
+  Trace = "TRC",
+  Debug = "DBG",
+  Info = "INF",
+  Warn = "WRN",
+  Error = "ERR",
+  Log = "LOG"
+}

--- a/packages/logger/lib/logger.ts
+++ b/packages/logger/lib/logger.ts
@@ -1,0 +1,146 @@
+import { ConsoleTransport } from "@node-lightning/logger";
+import util from "util";
+import { LogLevel } from "./log-level";
+import { ITransport } from "./transport";
+import { shouldLog } from "./util";
+
+export interface ILogger {
+    area: string;
+    instance: string;
+    format: boolean;
+    trace(...args: any[]): void;
+    debug(...args: any[]): void;
+    info(...args: any[]): void;
+    warn(...args: any[]): void;
+    error(...args: any[]): void;
+    sub(area: string, instance?: string, format?: boolean): ILogger;
+}
+
+export class Logger implements ILogger {
+    public readonly area: string;
+    public readonly instance: string;
+    public readonly format: boolean;
+
+    private _transports: ITransport[];
+    private _level: LogLevel;
+    private _root: Logger;
+
+    constructor(area: string = "", instance?: string, format: boolean = true) {
+        this._root = this;
+        this.area = area;
+        this.instance = instance;
+        this.format = format;
+        this._level = LogLevel.Info;
+        this._transports = [];
+
+        // create bound methods so consumer doesnt lose context
+        this.trace = this.trace.bind(this);
+        this.debug = this.debug.bind(this);
+        this.info = this.info.bind(this);
+        this.warn = this.warn.bind(this);
+        this.error = this.error.bind(this);
+        this.log = this.log.bind(this);
+    }
+
+    /**
+     * Configured log-level
+     */
+    get level() {
+        return this._root._level;
+    }
+
+    set level(value: LogLevel) {
+        this._root._level = value;
+    }
+
+    /**
+     * Gets the available transports
+     */
+    get transports() {
+        return this._root._transports;
+    }
+
+    /**
+     * Constructs a sub-logger under the current parent
+     * @param area optional area, if not provided it inherits from the parent
+     * @param instance optional instance, if not provied it inherits from the parent
+     */
+    public sub(area?: string, instance?: string, format: boolean = true): ILogger {
+        const logger = new Logger(area || this.area, instance || this.instance, format || this.format);
+        logger._root = this._root;
+        return logger;
+    }
+
+    public log(...args: any[]) {
+        this._log(LogLevel.Log, this.area, this.instance, args);
+    }
+
+    /**
+     * Write a trace message
+     */
+    public trace(...args: any[]) {
+        this._log(LogLevel.Trace, this.area, this.instance, args);
+    }
+
+    /**
+     * Write a debug message
+     * @param args variadic arguments
+     */
+    public debug(...args: any[]) {
+        this._log(LogLevel.Debug, this.area, this.instance, args);
+    }
+
+    /**
+     * Write an info message
+     * @param args variadic arguments
+     */
+    public info(...args: any[]) {
+        this._log(LogLevel.Info, this.area, this.instance, args);
+    }
+
+    /**
+     * Write a warning message
+     * @param args variadic arguments
+     */
+    public warn(...args: any[]) {
+        this._log(LogLevel.Warn, this.area, this.instance, args);
+    }
+
+    /**
+     * Write an error message
+     * @param args variadic arguments
+     */
+    public error(...args: any[]) {
+        this._log(LogLevel.Error, this.area, this.instance, args);
+    }
+
+    /////////////////////////////
+
+    private _log(level: LogLevel, area: string, instance: string, args: any[]) {
+        if (!shouldLog(this.level, level)) return;
+        const formattedMsg = this._format(level, area, instance, args);
+        this._write(formattedMsg);
+    }
+
+    private _format(level: LogLevel, area: string, instance: string, args: any[]): string {
+        const date = new Date().toISOString();
+        const formattedArea = area ? " " + area : "";
+        const instanceFmt = instance ? " " + instance : "";
+
+        // convert buffers to hex encodings
+        args = args.map(arg => (Buffer.isBuffer(arg) ? arg.toString("hex") : arg));
+
+        const msg = util.format(args[0], ...args.slice(1));
+        if (this.format) {
+          return `${date} [${level}]${formattedArea}${instanceFmt}: ${msg}`;
+        } else {
+          return msg;
+        }
+    }
+
+    private _write(msg: string) {
+        for (const transport of this._root.transports) {
+            transport.write(msg);
+        }
+    }
+}

--- a/packages/logger/lib/transport.ts
+++ b/packages/logger/lib/transport.ts
@@ -1,0 +1,5 @@
+import { LogLevel } from "./log-level";
+
+export interface ITransport {
+  write(line: string, level?: LogLevel): void;
+}

--- a/packages/logger/lib/transports/console-transport.ts
+++ b/packages/logger/lib/transports/console-transport.ts
@@ -1,0 +1,27 @@
+import { LogLevel } from "../log-level";
+import { ITransport } from "../transport";
+
+export class ConsoleTransport implements ITransport {
+    public console: Console;
+
+    constructor(console: Console) {
+        this.console = console;
+    }
+
+    public write(line: string, level?: LogLevel) {
+        switch (level) {
+            case LogLevel.Trace:
+                this.console.trace(line);
+            case LogLevel.Debug:
+                this.console.debug(line);
+            case LogLevel.Info:
+                this.console.info(line);
+            case LogLevel.Warn:
+                this.console.warn(line);
+            case LogLevel.Error:
+                this.console.error(line);
+            default:
+                this.console.log(line);
+        }
+    }
+}

--- a/packages/logger/lib/util.ts
+++ b/packages/logger/lib/util.ts
@@ -1,0 +1,32 @@
+import { LogLevel } from "./log-level";
+
+/**
+ * Helper function to determine if a log message is at the appropraite
+ * level to be included in the logs
+ * @param myLevel
+ * @param msgLevel
+ */
+export function shouldLog(myLevel: LogLevel, msgLevel: LogLevel): boolean {
+    if (msgLevel === LogLevel.Log) { return true; }
+    switch (myLevel) {
+        case LogLevel.Trace:
+            return true;
+        case LogLevel.Debug:
+            return (
+                msgLevel === LogLevel.Debug ||
+                msgLevel === LogLevel.Info ||
+                msgLevel === LogLevel.Warn ||
+                msgLevel === LogLevel.Error
+            );
+        case LogLevel.Info:
+            return (
+                msgLevel === LogLevel.Info ||
+                msgLevel === LogLevel.Warn ||
+                msgLevel === LogLevel.Error
+            );
+        case LogLevel.Warn:
+            return msgLevel === LogLevel.Warn || msgLevel === LogLevel.Error;
+        case LogLevel.Error:
+            return msgLevel === LogLevel.Error;
+    }
+}

--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "@node-dlc/logger",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@node-dlc/logger",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@node-lightning/bufio": "^0.21.1",
+        "@node-lightning/logger": "0.21.1"
+      }
+    },
+    "node_modules/@node-lightning/bufio": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@node-lightning/bufio/-/bufio-0.21.1.tgz",
+      "integrity": "sha512-mBJwbBKPh+wyajjOWemf36Y9Y+9Ed7Qsj2e8vf7SqTwZhiEDl9P+8skFKi1hSjy+TpF6VVl9UWFgf4Nv7DRbNg=="
+    },
+    "node_modules/@node-lightning/logger": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@node-lightning/logger/-/logger-0.21.1.tgz",
+      "integrity": "sha512-iRqYukgArr6yRvPnGvy3WU4WcR3sfZTGlzlafwOcTCgALXEfIkPFn6aYioHMRLm5UtURIZEfpH0lsX0UXl2Uvg=="
+    }
+  },
+  "dependencies": {
+    "@node-lightning/bufio": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@node-lightning/bufio/-/bufio-0.21.1.tgz",
+      "integrity": "sha512-mBJwbBKPh+wyajjOWemf36Y9Y+9Ed7Qsj2e8vf7SqTwZhiEDl9P+8skFKi1hSjy+TpF6VVl9UWFgf4Nv7DRbNg=="
+    },
+    "@node-lightning/logger": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@node-lightning/logger/-/logger-0.21.1.tgz",
+      "integrity": "sha512-iRqYukgArr6yRvPnGvy3WU4WcR3sfZTGlzlafwOcTCgALXEfIkPFn6aYioHMRLm5UtURIZEfpH0lsX0UXl2Uvg=="
+    }
+  }
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@node-dlc/logger",
+  "version": "0.1.0",
+  "description": "DLC Logger",
+  "scripts": {
+    "test": "../../node_modules/.bin/nyc --reporter=lcov --reporter=text --extension=.ts ../../node_modules/.bin/mocha --require ts-node/register --recursive \"__tests__/**/*.spec.*\"",
+    "lint": "../../node_modules/.bin/tslint --project tsconfig.json --config ../../tslint.json",
+    "lint:fix": "../../node_modules/.bin/tslint --fix --project tsconfig.json --config ../../tslint.json",
+    "build": "../../node_modules/.bin/tsc --project tsconfig.json",
+    "prepublish": "npm run build"
+  },
+  "keywords": [
+    "dlc",
+    "logger"
+  ],
+  "author": "Matthew Black <matthew@atomic.finance>",
+  "homepage": "https://github.com/atomicfinance/node-dlc/tree/master/packages/logger",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/atomicfinance/node-dlc.git"
+  },
+  "dependencies": {
+    "@node-lightning/bufio": "^0.21.1",
+    "@node-lightning/logger": "0.21.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+  },
+  "include": ["./lib"]
+}


### PR DESCRIPTION
This module is a fork of @node-lightning/logger.

However, it makes some small modifications to allow formatting to be turned off and for console.log to be used