### PR TITLE
Switch EnumEventDescriptor outcomes from Buffer to string

### DIFF
--- a/packages/messaging/__tests__/messages/EnumEventDescriptorV0.spec.ts
+++ b/packages/messaging/__tests__/messages/EnumEventDescriptorV0.spec.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { EnumEventDescriptorV0 } from '../../lib/messages/EnumEventDescriptorV0';
 
 describe('EnumEventDescriptorV0', () => {
-  const outcomeOne = Buffer.from('64756d6d7931', 'hex');
+  const outcomeOne = Buffer.from('64756d6d7931', 'hex').toString();
 
-  const outcomeTwo = Buffer.from('64756d6d7932', 'hex');
+  const outcomeTwo = Buffer.from('64756d6d7932', 'hex').toString();
 
   describe('serialize', () => {
     it('serializes', () => {

--- a/packages/messaging/lib/messages/EnumEventDescriptorV0.ts
+++ b/packages/messaging/lib/messages/EnumEventDescriptorV0.ts
@@ -22,7 +22,8 @@ export class EnumEventDescriptorV0 implements IDlcMessage {
 
     while (!reader.eof) {
       const outcomeLen = reader.readBigSize();
-      instance.outcomes.push(reader.readBytes(Number(outcomeLen)));
+      const outcomeBuf = reader.readBytes(Number(outcomeLen));
+      instance.outcomes.push(outcomeBuf.toString());
     }
 
     return instance;
@@ -35,7 +36,7 @@ export class EnumEventDescriptorV0 implements IDlcMessage {
 
   public length: bigint;
 
-  public outcomes: Buffer[] = [];
+  public outcomes: string[] = [];
 
   /**
    * Serializes the enum_event_descriptor_v0 message into a Buffer
@@ -49,7 +50,7 @@ export class EnumEventDescriptorV0 implements IDlcMessage {
 
     for (const outcome of this.outcomes) {
       dataWriter.writeBigSize(outcome.length);
-      dataWriter.writeBytes(outcome);
+      dataWriter.writeBytes(Buffer.from(outcome));
     }
 
     writer.writeBigSize(dataWriter.size);


### PR DESCRIPTION
Switch EnumEventdescriptor outcome field to string to follow [DLC Specs](https://github.com/discreetlogcontracts/dlcspecs/) [`enum_event_descriptor_v1`](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#version-0-enum_event_descriptor)