### PR TITLE
Revert digit decomposition tlv base

### DIFF
--- a/packages/messaging/__tests__/messages/DigitDecompositionEventDescriptorV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DigitDecompositionEventDescriptorV0.spec.ts
@@ -7,7 +7,12 @@ describe('DigitDecompositionEventDescriptorV0', () => {
       const instance = new DigitDecompositionEventDescriptorV0();
 
       instance.length = BigInt(17);
-      instance.base = BigInt(2);
+      /**
+       * NOTE: BASE IS INCORRECT FORMAT FOR DLC SPEC (SHOULD BE BIGSIZE)
+       * Will be fixed in oracle_announcement_v1
+       * https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#version-0-digit_decomposition_event_descriptor
+       */
+      instance.base = 2;
       instance.isSigned = false;
       instance.unit = 'btc/usd';
       instance.precision = 0;
@@ -15,8 +20,8 @@ describe('DigitDecompositionEventDescriptorV0', () => {
 
       expect(instance.serialize().toString("hex")).to.equal(
         'fdd80a' + // type
-        '10' + // length
-        '02' + // base
+        '11' + // length
+        '0002' + // base (Switch to '02' with oracle_announcement_v1)
         '00' + // isSigned
         '07' + // unit_Len
         '6274632f757364' + // btc/usd (unit)
@@ -31,7 +36,7 @@ describe('DigitDecompositionEventDescriptorV0', () => {
       const buf = Buffer.from(
         'fdd80a' + // type
         '11' + // length
-        '02' + // base
+        '0002' + // base (Switch to '02' with oracle_announcement_v1)
         '00' + // isSigned
         '07' + // unit_Len
         '6274632f757364' + // btc/usd (unit)
@@ -43,7 +48,7 @@ describe('DigitDecompositionEventDescriptorV0', () => {
       const instance = DigitDecompositionEventDescriptorV0.deserialize(buf);
 
       expect(Number(instance.length)).to.equal(17);
-      expect(Number(instance.base)).to.equal(2);
+      expect(instance.base).to.equal(2); // (Switch to Number(instance.base) with oracle_announcement_v1)
       expect(instance.isSigned).to.equal(false);
       expect(instance.unit).to.equal('btc/usd');
       expect(instance.precision).to.equal(0);

--- a/packages/messaging/__tests__/messages/OracleAnnouncementV0.spec.ts
+++ b/packages/messaging/__tests__/messages/OracleAnnouncementV0.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { OracleAnnouncementV0 } from '../../lib/messages/OracleAnnouncementV0';
 import { OracleEventV0 } from '../../lib/messages/OracleEventV0';
+import { DigitDecompositionEventDescriptorV0 } from '../../lib/messages/EventDescriptor';
 
 describe('OracleAnnouncementV0', () => {
   const announcementSig = Buffer.from(
@@ -111,6 +112,47 @@ describe('OracleAnnouncementV0', () => {
           '05' + // event_id_length
           '64756d6d79', // event_id
       );
+    });
+  });
+
+  /**
+   * External Test Vectors
+   * i.e. Suredbits Oracle: https://oracle.suredbits.com/event/1985a5e99a8c28a402b58c0c58cbf86bd66a0db850aafc7674f7226d5ce82fde
+   * oracle_announcement_v0
+   */
+  describe('external test vectors', () => {
+    it('deserializes', async () => {
+      const buf = Buffer.from(
+        'fdd824fd02ab1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937eb8b005b07acf849ad2cec22107331dedbf5a607654fad4eafe39c278e27dde68fdd822fd02450011f9313f1edd903fab297d5350006b669506eb0ffda0bb58319b4df89ac24e14fd15f9791dc78d1596b06f4969bdb37d9e394dc9fedaa18d694027fa32b5ea2a5e60080c58e13727367c3a4ce1ad65dfb3c7e3ca1ea912b0299f6e383bab2875058aa96a1c74633130af6fbd008788de6ac9db76da4ecc7303383cc1a49f525316413850f7e3ac385019d560e84c5b3a3e9ae6c83f59fe4286ddfd23ea46d7ae04610a175cd28a9bf5f574e245c3dfe230dc4b0adf4daaea96780e594f6464f676505f4b74cfe3ffc33415a23de795bf939ce64c0c02033bbfc6c9ff26fb478943a1ece775f38f5db067ca4b2a9168b40792398def9164bfe5c46838472dc3c162af16c811b7a116e9417d5bccb9e5b8a5d7d26095aba993696188c3f85a02f7ab8d12ada171c352785eb63417228c7e248909fc2d673e1bb453140bf8bf429375819afb5e9556663b76ff09c2a7ba9779855ffddc6d360cb459cf8c42a2b949d0de19fe96163d336fd66a4ce2f1791110e679572a20036ffae50204ef520c01058ff4bef28218d1c0e362ee3694ad8b2ae83a51c86c4bc1630ed6202a158810096726f809fc828fafdcf053496affdf887ae8c54b6ca4323ccecf6a51121c4f0c60e790536dab41b221db1c6b35065dc19a9d31cf75901aa35eefecbb6fefd07296cda13cb34ce3b58eba20a0eb8f9614994ec7fee3cc290e30e6b1e3211ae1f3a85b6de6abdbb77d6d9ed33a1cee3bd5cd93a71f12c9c45e385d744ad0e7286660305100fdd80a11000200076274632f75736400000000001109425443205072696365',
+        'hex',
+      );
+
+      const instance = OracleAnnouncementV0.deserialize(buf);
+
+      expect(Number(instance.length)).to.equal(683);
+      expect(instance.announcementSig).to.deep.equal(
+        Buffer.from(
+          '1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937e',
+          'hex',
+        ),
+      );
+      expect(instance.oraclePubkey).to.deep.equal(
+        Buffer.from(
+          'b8b005b07acf849ad2cec22107331dedbf5a607654fad4eafe39c278e27dde68',
+          'hex',
+        ),
+      );
+      expect(instance.oracleEvent.oracleNonces[0]).to.deep.equal(
+        Buffer.from(
+          'f9313f1edd903fab297d5350006b669506eb0ffda0bb58319b4df89ac24e14fd',
+          'hex',
+        ),
+      );
+      expect(instance.oracleEvent.eventMaturityEpoch).to.equal(1613779200);
+      expect(
+        (instance.oracleEvent
+          .eventDescriptor as DigitDecompositionEventDescriptorV0).unit,
+      ).to.equal('btc/usd');
     });
   });
 });

--- a/packages/messaging/lib/messages/EventDescriptor.ts
+++ b/packages/messaging/lib/messages/EventDescriptor.ts
@@ -108,7 +108,12 @@ export class DigitDecompositionEventDescriptorV0
     reader.readBigSize(); // read type
     instance.length = reader.readBigSize(); // need to fix this
 
-    instance.base = reader.readBigSize();
+    /**
+     * NOTE: BASE IS INCORRECT FORMAT FOR DLC SPEC (SHOULD BE BIGSIZE)
+     * Will be fixed in oracle_announcement_v1
+     * https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#version-0-digit_decomposition_event_descriptor
+     */
+    instance.base = reader.readUInt16BE();
     instance.isSigned = reader.readUInt8() === 1;
     const unitLen = reader.readBigSize();
     const unitBuf = reader.readBytes(Number(unitLen));
@@ -126,7 +131,7 @@ export class DigitDecompositionEventDescriptorV0
 
   public length: bigint;
 
-  public base: bigint;
+  public base: number; // Switch to bigint in oracle_announcement_v1
 
   public isSigned: boolean;
 
@@ -144,7 +149,7 @@ export class DigitDecompositionEventDescriptorV0
     writer.writeBigSize(this.type);
 
     const dataWriter = new BufferWriter();
-    dataWriter.writeBigSize(this.base);
+    dataWriter.writeUInt16BE(this.base); // Switch to BigSize in oracle_announcement_v1
     dataWriter.writeUInt8(this.isSigned ? 1 : 0);
     dataWriter.writeBigSize(this.unit.length);
     dataWriter.writeBytes(Buffer.from(this.unit));

--- a/packages/messaging/lib/messages/OracleEventV0.ts
+++ b/packages/messaging/lib/messages/OracleEventV0.ts
@@ -2,7 +2,7 @@ import { BufferReader, BufferWriter } from '@node-lightning/bufio';
 import { MessageType } from '../MessageType';
 import { getTlv } from '../serialize/getTlv';
 import { IDlcMessage } from './DlcMessage';
-import { EnumEventDescriptorV0, EventDescriptor } from './EventDescriptor';
+import { EventDescriptor } from './EventDescriptor';
 
 /**
  * For users to be able to create DLCs based on a given event, they also
@@ -36,9 +36,7 @@ export class OracleEventV0 implements IDlcMessage {
     }
 
     instance.eventMaturityEpoch = reader.readUInt32BE();
-    instance.eventDescriptor = EnumEventDescriptorV0.deserialize(
-      getTlv(reader),
-    );
+    instance.eventDescriptor = EventDescriptor.deserialize(getTlv(reader));
     const eventIdLength = reader.readBigSize();
     const eventIdBuf = reader.readBytes(Number(eventIdLength));
     instance.eventId = eventIdBuf.toString();


### PR DESCRIPTION
The current DLC Spec specifies DigitDecompositionEventDescriptor TLV should have `base` as `bigsize`. However current external oracle implementation use `uint16` currently instead. 

https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#version-0-digit_decomposition_event_descriptor

Since all oracles will be switching to oracle_announcement_v1 soon, this issue will be fixed with v1 release. For now use incorrect v0 serialization until v1 release. 

- [x] Convert DigitDecompositionEventDescriptor `base` to `uint16`
- [x] Update tests
- [x] Add external test vectors (i.e. Suredbits oracle: https://oracle.suredbits.com/event/1985a5e99a8c28a402b58c0c58cbf86bd66a0db850aafc7674f7226d5ce82fde)

