### PR TITLE
Fix DlcOffer abstract type deserialization

### DIFF
--- a/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import { ContractInfo } from '../../lib/messages/ContractInfo';
 import { FundingInputV0 } from '../../lib/messages/FundingInput';
-import { DlcOfferV0 } from '../../lib/messages/DlcOffer';
+import { DlcOffer, DlcOfferV0 } from '../../lib/messages/DlcOffer';
+import { MessageType } from '../../lib/MessageType';
 
 describe('DlcOfferV0', () => {
   const contractFlags = Buffer.from('00', 'hex');
@@ -248,66 +249,70 @@ describe('DlcOfferV0', () => {
         , "hex"
       ); // prettier-ignore
 
-      const instance = DlcOfferV0.deserialize(buf);
+      const unknownInstance = DlcOffer.deserialize(buf);
 
-      expect(instance.contractFlags).to.deep.equal(contractFlags);
-      expect(instance.chainHash).to.deep.equal(chainHash);
-      expect(instance.contractInfo.serialize().toString('hex')).to.equal(
-        'fdd82e' + // type contract_info
-          'fd0131' + // length
-          '000000000bebc200' + // total_collateral
-          'fda710' + // type contract_descriptor
-          '79' + // length
-          '03' + // num_outcomes
-          'c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722' + // outcome_1
-          '0000000000000000' + // payout_1
-          'adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead' + // outcome_2
-          '00000000092363a3' + // payout_2
-          '6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288' + // outcome_3
-          '000000000bebc200' + // payout_3
-          'fda712' + // type oracle_info
-          'a8' + // length
-          'fdd824' + // type oracle_announcement
-          'a4' + // length
-          'fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9' + // announcement_signature_r
-          '494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4' + // announcement_signature_s
-          'da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b' + // oracle_public_key
-          'fdd822' + // type oracle_event
-          '40' + // length
-          '0001' + // nb_nonces
-          '3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b' + // oracle_nonces
-          '00000000' + // event_maturity_epoch
-          'fdd806' + // type enum_event_descriptor
-          '10' + // length
-          '0002' + // num_outcomes
-          '06' + // outcome_1_len
-          '64756d6d7931' + // outcome_1
-          '06' + // outcome_2_len
-          '64756d6d7932' + // outcome_2
-          '05' + // event_id_length
-          '64756d6d79', // event_id
-      );
-      expect(instance.fundingPubKey).to.deep.equal(fundingPubKey);
-      expect(instance.payoutSPK).to.deep.equal(payoutSPK);
-      expect(Number(instance.payoutSerialId)).to.equal(11555292);
-      expect(Number(instance.offerCollateralSatoshis)).to.equal(100000000);
-      expect(instance.fundingInputs[0].serialize().toString('hex')).to.equal(
-        'fda714' +
-          '3f' + // length
-          '000000000000fa51' + // input_serial_id
-          '0029' + // prevtx_len
-          '02000000000100c2eb0b00000000160014369d63a82ed846f4d47ad55045e594ab95539d6000000000' + // prevtx
-          '00000000' + // prevtx_vout
-          'ffffffff' + // sequence
-          '006b' + // max_witness_len
-          '0000', // redeemscript_len
-      );
-      expect(instance.changeSPK).to.deep.equal(changeSPK);
-      expect(Number(instance.changeSerialId)).to.equal(2008045);
-      expect(Number(instance.fundOutputSerialId)).to.equal(5411962);
-      expect(Number(instance.feeRatePerVb)).to.equal(1);
-      expect(instance.cetLocktime).to.equal(100);
-      expect(instance.refundLocktime).to.equal(200);
+      if (unknownInstance.type === MessageType.ContractInfoV0) {
+        const instance = unknownInstance as DlcOfferV0;
+
+        expect(instance.contractFlags).to.deep.equal(contractFlags);
+        expect(instance.chainHash).to.deep.equal(chainHash);
+        expect(instance.contractInfo.serialize().toString('hex')).to.equal(
+          'fdd82e' + // type contract_info
+            'fd0131' + // length
+            '000000000bebc200' + // total_collateral
+            'fda710' + // type contract_descriptor
+            '79' + // length
+            '03' + // num_outcomes
+            'c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722' + // outcome_1
+            '0000000000000000' + // payout_1
+            'adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead' + // outcome_2
+            '00000000092363a3' + // payout_2
+            '6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288' + // outcome_3
+            '000000000bebc200' + // payout_3
+            'fda712' + // type oracle_info
+            'a8' + // length
+            'fdd824' + // type oracle_announcement
+            'a4' + // length
+            'fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9' + // announcement_signature_r
+            '494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4' + // announcement_signature_s
+            'da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b' + // oracle_public_key
+            'fdd822' + // type oracle_event
+            '40' + // length
+            '0001' + // nb_nonces
+            '3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b' + // oracle_nonces
+            '00000000' + // event_maturity_epoch
+            'fdd806' + // type enum_event_descriptor
+            '10' + // length
+            '0002' + // num_outcomes
+            '06' + // outcome_1_len
+            '64756d6d7931' + // outcome_1
+            '06' + // outcome_2_len
+            '64756d6d7932' + // outcome_2
+            '05' + // event_id_length
+            '64756d6d79', // event_id
+        );
+        expect(instance.fundingPubKey).to.deep.equal(fundingPubKey);
+        expect(instance.payoutSPK).to.deep.equal(payoutSPK);
+        expect(Number(instance.payoutSerialId)).to.equal(11555292);
+        expect(Number(instance.offerCollateralSatoshis)).to.equal(100000000);
+        expect(instance.fundingInputs[0].serialize().toString('hex')).to.equal(
+          'fda714' +
+            '3f' + // length
+            '000000000000fa51' + // input_serial_id
+            '0029' + // prevtx_len
+            '02000000000100c2eb0b00000000160014369d63a82ed846f4d47ad55045e594ab95539d6000000000' + // prevtx
+            '00000000' + // prevtx_vout
+            'ffffffff' + // sequence
+            '006b' + // max_witness_len
+            '0000', // redeemscript_len
+        );
+        expect(instance.changeSPK).to.deep.equal(changeSPK);
+        expect(Number(instance.changeSerialId)).to.equal(2008045);
+        expect(Number(instance.fundOutputSerialId)).to.equal(5411962);
+        expect(Number(instance.feeRatePerVb)).to.equal(1);
+        expect(instance.cetLocktime).to.equal(100);
+        expect(instance.refundLocktime).to.equal(200);
+      }
     });
   });
 });

--- a/packages/messaging/lib/messages/DlcOffer.ts
+++ b/packages/messaging/lib/messages/DlcOffer.ts
@@ -9,7 +9,7 @@ export abstract class DlcOffer {
   public static deserialize(buf: Buffer): DlcOfferV0 {
     const reader = new BufferReader(buf);
 
-    const type = Number(reader.readBigSize());
+    const type = Number(reader.readUInt16BE());
 
     switch (type) {
       case MessageType.DlcOfferV0:

--- a/packages/messaging/lib/messages/DlcTransactions.ts
+++ b/packages/messaging/lib/messages/DlcTransactions.ts
@@ -7,7 +7,7 @@ export abstract class DlcTransactions {
   public static deserialize(buf: Buffer): DlcTransactionsV0 {
     const reader = new BufferReader(buf);
 
-    const type = Number(reader.readBigSize());
+    const type = Number(reader.readUInt16BE());
 
     switch (type) {
       case MessageType.DlcTransactionsV0:


### PR DESCRIPTION
Fix DlcOffer abstract type deserialization

DlcOffer should use `readUInt16BE` not `readBigSize`

This is also applied to unfinished type `DlcTransactions` as well