### PR TITLE
Switch hyperbola check to type check instead of instanceof

### DIFF
--- a/packages/core/lib/dlc/finance/CoveredCall.ts
+++ b/packages/core/lib/dlc/finance/CoveredCall.ts
@@ -2,6 +2,7 @@ import {
   PayoutFunctionV0,
   RoundingIntervalsV0,
   HyperbolaPayoutCurvePiece,
+  MessageType,
 } from '@node-dlc/messaging';
 import BN from 'bignumber.js';
 import { toBigInt } from '../../utils/BigIntUtils';
@@ -100,10 +101,12 @@ const computePayouts = (
     payoutCurvePiece,
   } = payoutFunction.pieces[0];
 
-  if (!(payoutCurvePiece instanceof HyperbolaPayoutCurvePiece))
+  if (payoutCurvePiece.type !== MessageType.HyperbolaPayoutCurvePiece)
     throw new Error('Payout curve piece must be a hyperbola');
 
-  const curve = HyperbolaPayoutCurve.fromPayoutCurvePiece(payoutCurvePiece);
+  const _payoutCurvePiece = payoutCurvePiece as HyperbolaPayoutCurvePiece;
+
+  const curve = HyperbolaPayoutCurve.fromPayoutCurvePiece(_payoutCurvePiece);
 
   return splitIntoRanges(
     payoutFunction.endpoint0,


### PR DESCRIPTION
Currently when @node-dlc/core is used externally, there are issues with checking `instanceof`. This PR ensures that `type` is checked instead of class check `instanceof`