### PR TITLE
Add getAddresses to DlcOffer and DlcAccept

### DIFF
--- a/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
@@ -4,6 +4,7 @@ import { DlcAccept, DlcAcceptV0 } from '../../lib/messages/DlcAccept';
 import { CetAdaptorSignaturesV0 } from '../../lib/messages/CetAdaptorSignaturesV0';
 import { NegotiationFields } from '../../lib/messages/NegotiationFields';
 import { MessageType } from '../../lib/MessageType';
+import BitcoinNetworks from '@liquality/bitcoin-networks';
 
 describe('DlcAcceptV0', () => {
   const tempContractId = Buffer.from(
@@ -30,6 +31,43 @@ describe('DlcAcceptV0', () => {
     '7c8ad6de287b62a1ed1d74ed9116a5158abc7f97376d201caa88e0f9daad68fcda4c271cc003512e768f403a57e5242bd1f6aa1750d7f3597598094a43b1c7bb',
     'hex',
   );
+
+  const bitcoinNetwork = BitcoinNetworks.bitcoin_regtest;
+
+  const dlcAcceptHex = Buffer.from(
+    "a71c" + // type accept_dlc_v0
+    "960fb5f7960382ac7e76f3e24eb6b00059b1e68632a946843c22e1f65fdf216a" + // temp_contract_id
+    "0000000005f5e100" + // total_collateral_satoshis
+    "026d8bec9093f96ccc42de166cb9a6c576c95fc24ee16b10e87c3baaa4e49684d9" + // funding_pubkey
+    "0016" + // payout_spk_len
+    "001436054fa379f7564b5e458371db643666365c8fb3" + // payout_spk
+    "000000000018534a" + // payout_serial_id
+    "0001" + // funding_inputs_len
+    "fda714" + // type funding_input_v0
+    "3f" + // length
+    "000000000000dae8" + // input_serial_id
+    "0029" + // prevtx_len
+    "02000000000100c2eb0b000000001600149ea3bf2d6eb9c2ffa35e36f41e117403ed7fafe900000000" + // prevtx
+    "00000000" + // prevtx_vout
+    "ffffffff" + // sequence
+    "006b" + // max_witness_len
+    "0000" + // redeem_script_len
+    "0016" + // change_spk_len
+    "0014074c82dbe058212905bacc61814456b7415012ed" + // change_spk
+    "00000000000d8117" + // change_serial_id
+    "fda716" + // type cet_adaptor_signatures_v0
+    "fd01e7" + // length
+    "03" + // nb_signatures
+    "016292f1b5c67b675aea69c95ec81e8462ab5bb9b7a01f810f6d1a7d1d886893b3605fe7fcb75a14b1b1de917917d37e9efac6437d7a080da53fb6dbbcfbfbe7a8" + // ecdsa_adaptor_signature_1
+    "01efbecb2bce89556e1fb4d31622628830e02a6d04c487f67aca20e9f60fb127f985293541cd14e2bf04e4777d50953531e169dd37c65eb3cc17d6b5e4dbe58487f9fae1f68f603fe014a699a346b14a63048c26c9b31236d83a7e369a2b29a292" + // dleq_proof_1
+    "00e52fe05d832bcce4538d9c27f3537a0f2086b265b6498f30cf667f77ff2fa87606574bc9a915ef57f7546ebb6852a490ad0547bdc52b19791d2d0f0cc0acabab" + // ecdsa_adaptor_signature_2
+    "01f32459001a28850fa8ee4278111deb0494a8175f02e31a1c18b39bd82ec64026a6f341bcd5ba169d67b855030e36bdc65feecc0397a07d3bc514da69811ec5485f5553aebda782bc5ac9b47e8e11d701a38ef2c2b7d8af3906dd8dfc759754ce" + // dleq_proof_2
+    "006f769592c744141a5ddface6e98f756a9df1bb75ad41508ea013bdfee133b396d85be51f870bf2e0ae836bfa984109dab96cc6f4ab2a7f118bc6b0b25a4c70d4" + // ecdsa_adaptor_signature_3
+    "01c768c1d677c6ff0b7ea69fdf29aff1000794227db368dff16e838d1f44c4afe9e952ee63d603f7b14de13c1d73b363cc2b1740d0b688e73d8e71cddf40f8e7e912df413903779c4e5d6644c504c8609baec8fdcb90d6d341cf316748f5d7945f" +
+    "7c8ad6de287b62a1ed1d74ed9116a5158abc7f97376d201caa88e0f9daad68fcda4c271cc003512e768f403a57e5242bd1f6aa1750d7f3597598094a43b1c7bb" + // refund_signature
+    "fdd82600" // negotiation_fields
+    , "hex"
+  ); // prettier-ignore
 
   describe('serialize', () => {
     it('serializes', () => {
@@ -115,42 +153,7 @@ describe('DlcAcceptV0', () => {
 
   describe('deserialize', () => {
     it('deserializes', () => {
-      const buf = Buffer.from(
-        "a71c" + // type accept_dlc_v0
-        "960fb5f7960382ac7e76f3e24eb6b00059b1e68632a946843c22e1f65fdf216a" + // temp_contract_id
-        "0000000005f5e100" + // total_collateral_satoshis
-        "026d8bec9093f96ccc42de166cb9a6c576c95fc24ee16b10e87c3baaa4e49684d9" + // funding_pubkey
-        "0016" + // payout_spk_len
-        "001436054fa379f7564b5e458371db643666365c8fb3" + // payout_spk
-        "000000000018534a" + // payout_serial_id
-        "0001" + // funding_inputs_len
-        "fda714" + // type funding_input_v0
-        "3f" + // length
-        "000000000000dae8" + // input_serial_id
-        "0029" + // prevtx_len
-        "02000000000100c2eb0b000000001600149ea3bf2d6eb9c2ffa35e36f41e117403ed7fafe900000000" + // prevtx
-        "00000000" + // prevtx_vout
-        "ffffffff" + // sequence
-        "006b" + // max_witness_len
-        "0000" + // redeem_script_len
-        "0016" + // change_spk_len
-        "0014074c82dbe058212905bacc61814456b7415012ed" + // change_spk
-        "00000000000d8117" + // change_serial_id
-        "fda716" + // type cet_adaptor_signatures_v0
-        "fd01e7" + // length
-        "03" + // nb_signatures
-        "016292f1b5c67b675aea69c95ec81e8462ab5bb9b7a01f810f6d1a7d1d886893b3605fe7fcb75a14b1b1de917917d37e9efac6437d7a080da53fb6dbbcfbfbe7a8" + // ecdsa_adaptor_signature_1
-        "01efbecb2bce89556e1fb4d31622628830e02a6d04c487f67aca20e9f60fb127f985293541cd14e2bf04e4777d50953531e169dd37c65eb3cc17d6b5e4dbe58487f9fae1f68f603fe014a699a346b14a63048c26c9b31236d83a7e369a2b29a292" + // dleq_proof_1
-        "00e52fe05d832bcce4538d9c27f3537a0f2086b265b6498f30cf667f77ff2fa87606574bc9a915ef57f7546ebb6852a490ad0547bdc52b19791d2d0f0cc0acabab" + // ecdsa_adaptor_signature_2
-        "01f32459001a28850fa8ee4278111deb0494a8175f02e31a1c18b39bd82ec64026a6f341bcd5ba169d67b855030e36bdc65feecc0397a07d3bc514da69811ec5485f5553aebda782bc5ac9b47e8e11d701a38ef2c2b7d8af3906dd8dfc759754ce" + // dleq_proof_2
-        "006f769592c744141a5ddface6e98f756a9df1bb75ad41508ea013bdfee133b396d85be51f870bf2e0ae836bfa984109dab96cc6f4ab2a7f118bc6b0b25a4c70d4" + // ecdsa_adaptor_signature_3
-        "01c768c1d677c6ff0b7ea69fdf29aff1000794227db368dff16e838d1f44c4afe9e952ee63d603f7b14de13c1d73b363cc2b1740d0b688e73d8e71cddf40f8e7e912df413903779c4e5d6644c504c8609baec8fdcb90d6d341cf316748f5d7945f" +
-        "7c8ad6de287b62a1ed1d74ed9116a5158abc7f97376d201caa88e0f9daad68fcda4c271cc003512e768f403a57e5242bd1f6aa1750d7f3597598094a43b1c7bb" + // refund_signature
-        "fdd82600" // negotiation_fields
-        , "hex"
-      ); // prettier-ignore
-
-      const unknownInstance = DlcAccept.deserialize(buf);
+      const unknownInstance = DlcAccept.deserialize(dlcAcceptHex);
 
       if (unknownInstance.type === MessageType.DlcAcceptV0) {
         const instance = unknownInstance as DlcAcceptV0;
@@ -256,6 +259,35 @@ describe('DlcAcceptV0', () => {
       expect(jsonInstance.refundSignature).to.equal(
         refundSignature.toString('hex'),
       );
+    });
+  });
+
+  describe('getAddresses', () => {
+    it('should get addresses', async () => {
+      const expectedFundingAddress =
+        'bcrt1qrhzxd53jmv7znf0ywvcvpm06ndhgp5fcxjy57k';
+      const expectedChangeAddress =
+        'bcrt1qqaxg9klqtqsjjpd6e3scz3zkkaq4qyhd7rg6dd';
+      const expectedPayoutAddress =
+        'bcrt1qxcz5lgme7atykhj9sdcakepkvcm9eran32jk9c';
+
+      const unknownInstance = DlcAccept.deserialize(dlcAcceptHex);
+
+      if (unknownInstance.type === MessageType.DlcAcceptV0) {
+        const instance = unknownInstance as DlcAcceptV0;
+
+        const {
+          fundingAddress,
+          changeAddress,
+          payoutAddress,
+        } = await instance.getAddresses(bitcoinNetwork);
+
+        expect(fundingAddress).to.equal(expectedFundingAddress);
+        expect(changeAddress).to.equal(expectedChangeAddress);
+        expect(payoutAddress).to.equal(expectedPayoutAddress);
+      } else {
+        throw Error('DlcAccept Incorrect type');
+      }
     });
   });
 });

--- a/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
@@ -3,6 +3,7 @@ import { ContractInfo } from '../../lib/messages/ContractInfo';
 import { FundingInputV0 } from '../../lib/messages/FundingInput';
 import { DlcOffer, DlcOfferV0 } from '../../lib/messages/DlcOffer';
 import { MessageType } from '../../lib/MessageType';
+import BitcoinNetworks from '@liquality/bitcoin-networks';
 
 describe('DlcOfferV0', () => {
   const contractFlags = Buffer.from('00', 'hex');
@@ -26,6 +27,81 @@ describe('DlcOfferV0', () => {
     '0014afa16f949f3055f38bd3a73312bed00b61558884',
     'hex',
   );
+
+  const bitcoinNetwork = BitcoinNetworks.bitcoin_regtest;
+
+  const dlcOfferHex = Buffer.from(
+    "a71a" + // type
+    "00" + // contract_flags
+    "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f" + // chain_hash
+
+    "fdd82e" + // type contract_info
+    "fd0131" + // length
+    "000000000bebc200" + // total_collateral
+    "fda710" + // type contract_descriptor
+    "79" + // length
+    "03" + // num_outcomes
+    "c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722" + // outcome_1
+    "0000000000000000" + // payout_1
+    "adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead" + // outcome_2
+    "00000000092363a3" + // payout_2
+    "6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288" + // outcome_3
+    "000000000bebc200" + // payout_3
+    "fda712" + // type oracle_info
+    "a8" + // length
+    "fdd824" + // type oracle_announcement
+    "a4" + // length
+    "fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9" + // announcement_signature_r
+    "494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4" + // announcement_signature_s
+    "da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b" + // oracle_public_key
+    "fdd822" + // type oracle_event
+    "40" + // length
+    "0001" + // nb_nonces
+    "3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b" + // oracle_nonces
+    "00000000" + // event_maturity_epoch
+    "fdd806" + // type enum_event_descriptor
+    "10" + // length
+    "0002" + // num_outcomes
+    "06" + // outcome_1_len
+    "64756d6d7931" + // outcome_1
+    "06" + // outcome_2_len
+    "64756d6d7932" + // outcome_2
+    "05" + // event_id_length
+    "64756d6d79" + // event_id
+
+    "0327efea09ff4dfb13230e887cbab8821d5cc249c7ff28668c6633ff9f4b4c08e3" + // funding_pubkey
+
+    "0016" + // payout_spk_len
+    "00142bbdec425007dc360523b0294d2c64d2213af498" + // payout_spk
+
+    "0000000000b051dc" + // payout_serial_id
+
+    "0000000005f5e100" + // total_collateral_satoshis
+
+    "0001" + // funding_inputs_len
+    
+    "fda714" + // type funding_input
+    "3f" + // length
+    "000000000000fa51" + // input_serial_id
+    "0029" + // prevtx_len
+    "02000000000100c2eb0b00000000160014369d63a82ed846f4d47ad55045e594ab95539d6000000000" + // prevtx
+    "00000000" + // prevtx_vout
+    "ffffffff" + // sequence
+    "006b" + // max_witness_len
+    "0000" + // redeemscript_len
+
+    "0016" + // change_spk_len
+    "0014afa16f949f3055f38bd3a73312bed00b61558884" + // change_spk
+
+    "00000000001ea3ed" + // change_serial_id
+    "000000000052947a" + // funding_output_serial_id
+
+    "0000000000000001" + // fee_rate_per_vb
+
+    "00000064" + // cet_locktime
+    "000000c8" // refund_locktime
+    , "hex"
+  ); // prettier-ignore
 
   describe('serialize', () => {
     it('serializes', () => {
@@ -176,80 +252,7 @@ describe('DlcOfferV0', () => {
 
   describe('deserialize', () => {
     it('deserializes', () => {
-      const buf = Buffer.from(
-        "a71a" + // type
-        "00" + // contract_flags
-        "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f" + // chain_hash
-
-        "fdd82e" + // type contract_info
-        "fd0131" + // length
-        "000000000bebc200" + // total_collateral
-        "fda710" + // type contract_descriptor
-        "79" + // length
-        "03" + // num_outcomes
-        "c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722" + // outcome_1
-        "0000000000000000" + // payout_1
-        "adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead" + // outcome_2
-        "00000000092363a3" + // payout_2
-        "6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288" + // outcome_3
-        "000000000bebc200" + // payout_3
-        "fda712" + // type oracle_info
-        "a8" + // length
-        "fdd824" + // type oracle_announcement
-        "a4" + // length
-        "fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9" + // announcement_signature_r
-        "494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4" + // announcement_signature_s
-        "da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b" + // oracle_public_key
-        "fdd822" + // type oracle_event
-        "40" + // length
-        "0001" + // nb_nonces
-        "3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b" + // oracle_nonces
-        "00000000" + // event_maturity_epoch
-        "fdd806" + // type enum_event_descriptor
-        "10" + // length
-        "0002" + // num_outcomes
-        "06" + // outcome_1_len
-        "64756d6d7931" + // outcome_1
-        "06" + // outcome_2_len
-        "64756d6d7932" + // outcome_2
-        "05" + // event_id_length
-        "64756d6d79" + // event_id
-
-        "0327efea09ff4dfb13230e887cbab8821d5cc249c7ff28668c6633ff9f4b4c08e3" + // funding_pubkey
-
-        "0016" + // payout_spk_len
-        "00142bbdec425007dc360523b0294d2c64d2213af498" + // payout_spk
-
-        "0000000000b051dc" + // payout_serial_id
-
-        "0000000005f5e100" + // total_collateral_satoshis
-
-        "0001" + // funding_inputs_len
-        
-        "fda714" + // type funding_input
-        "3f" + // length
-        "000000000000fa51" + // input_serial_id
-        "0029" + // prevtx_len
-        "02000000000100c2eb0b00000000160014369d63a82ed846f4d47ad55045e594ab95539d6000000000" + // prevtx
-        "00000000" + // prevtx_vout
-        "ffffffff" + // sequence
-        "006b" + // max_witness_len
-        "0000" + // redeemscript_len
-
-        "0016" + // change_spk_len
-        "0014afa16f949f3055f38bd3a73312bed00b61558884" + // change_spk
-
-        "00000000001ea3ed" + // change_serial_id
-        "000000000052947a" + // funding_output_serial_id
-
-        "0000000000000001" + // fee_rate_per_vb
-
-        "00000064" + // cet_locktime
-        "000000c8" // refund_locktime
-        , "hex"
-      ); // prettier-ignore
-
-      const unknownInstance = DlcOffer.deserialize(buf);
+      const unknownInstance = DlcOffer.deserialize(dlcOfferHex);
 
       if (unknownInstance.type === MessageType.DlcOfferV0) {
         const instance = unknownInstance as DlcOfferV0;
@@ -312,6 +315,35 @@ describe('DlcOfferV0', () => {
         expect(Number(instance.feeRatePerVb)).to.equal(1);
         expect(instance.cetLocktime).to.equal(100);
         expect(instance.refundLocktime).to.equal(200);
+      } else {
+        throw Error('DlcOffer Incorrect type');
+      }
+    });
+  });
+
+  describe('getAddresses', () => {
+    it('should get addresses', async () => {
+      const expectedFundingAddress =
+        'bcrt1qayylp95g2tzq2a60x2l7f8mclnx5y2jxm0yt09';
+      const expectedChangeAddress =
+        'bcrt1q47skl9ylxp2l8z7n5ue390kspds4tzyy5jdxs8';
+      const expectedPayoutAddress =
+        'bcrt1q9w77csjsqlwrvpfrkq556try6gsn4ayc2kn0kl';
+
+      const unknownInstance = DlcOffer.deserialize(dlcOfferHex);
+
+      if (unknownInstance.type === MessageType.DlcOfferV0) {
+        const instance = unknownInstance as DlcOfferV0;
+
+        const {
+          fundingAddress,
+          changeAddress,
+          payoutAddress,
+        } = await instance.getAddresses(bitcoinNetwork);
+
+        expect(fundingAddress).to.equal(expectedFundingAddress);
+        expect(changeAddress).to.equal(expectedChangeAddress);
+        expect(payoutAddress).to.equal(expectedPayoutAddress);
       } else {
         throw Error('DlcOffer Incorrect type');
       }


### PR DESCRIPTION
This PR adds `getAddresses` to `DlcOffer` and `DlcAccept` which returns the address in bech32 format for payoutSPK (payoutAddress), changeSPK (changeAddress), and fundingPubkey (fundingAddress). 