### PR TITLE
Add ChainState to DlcTransactions

### DIFF
--- a/packages/messaging/__tests__/messages/DlcTransactionsV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcTransactionsV0.spec.ts
@@ -22,7 +22,7 @@ describe('DlcTransactionsV0', () => {
     ),
   );
 
-  const fundTxOutAmount = BigInt(971182);
+  const fundTxVout = 0;
 
   const refundTx = Tx.decode(
     StreamReader.fromBuffer(
@@ -57,7 +57,7 @@ describe('DlcTransactionsV0', () => {
 
       instance.contractId = contractId;
       instance.fundTx = fundTx;
-      instance.fundTxOutAmount = fundTxOutAmount;
+      instance.fundTxVout = fundTxVout;
       instance.refundTx = refundTx;
       instance.cets.push(cet0);
       instance.cets.push(cet1);
@@ -67,14 +67,15 @@ describe('DlcTransactionsV0', () => {
         "6010a7e779c5079493ad06abbcaca06b8a04d501890cd724104d1df6e20968e8" + // contract_id
         "00c5" + // fund_tx_len
         "02000000022f76d0509ca3ad7559e0f45489aa2efea70f8657e3cdfce6b8194019012370a10100000000ffffffffd295f485f2d181eb06ae6d5e62007db4bfe52ad31e6e1a5c576e2f396bbda9470100000000ffffffff03aed10e000000000022002034e21059bdd0c5d1d3f2d03075b33ec89c9a018a855158a6c605d921e41db8fd88f6dc0b00000000160014ccd5d5d8249b94c4381c478907c2ad81f0c35227f2b1eb0b000000001600149212ec2ed940f3cd93bfbd16c5f817ee079243bb00000000" +
-        "fe000ed1ae" +
+        "00000000000000000000000000000000000000000000000000000000000000000000000000000000" +
         "0071" + // refund_tx_len
         "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000feffffff023ac30e000000000016001442795b177d2bd1d538d379af766a979e4056d43cd007000000000000160014f9e38ab4d13bc36fd4df0381e355d9f7b50d69808c106460" +
         "02" + // num_cets
         "0052" + // cet_0_len
         "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000ffffffff010acb0e000000000016001442795b177d2bd1d538d379af766a979e4056d43c00000000" +
         "0052" + // cet_1_len
-        "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000ffffffff010acb0e000000000016001442795b177d2bd1d538d379af766a979e4056d43c00000000"
+        "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000ffffffff010acb0e000000000016001442795b177d2bd1d538d379af766a979e4056d43c00000000" +
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
       ); // prettier-ignore
     });
   });
@@ -86,14 +87,15 @@ describe('DlcTransactionsV0', () => {
         "6010a7e779c5079493ad06abbcaca06b8a04d501890cd724104d1df6e20968e8" + // contract_id
         "00c5" + // fund_tx_len
         "02000000022f76d0509ca3ad7559e0f45489aa2efea70f8657e3cdfce6b8194019012370a10100000000ffffffffd295f485f2d181eb06ae6d5e62007db4bfe52ad31e6e1a5c576e2f396bbda9470100000000ffffffff03aed10e000000000022002034e21059bdd0c5d1d3f2d03075b33ec89c9a018a855158a6c605d921e41db8fd88f6dc0b00000000160014ccd5d5d8249b94c4381c478907c2ad81f0c35227f2b1eb0b000000001600149212ec2ed940f3cd93bfbd16c5f817ee079243bb00000000" +
-        "fe000ed1ae" +
+        "00000000000000000000000000000000000000000000000000000000000000000000000000000000" +
         "0071" + // refund_tx_len
         "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000feffffff023ac30e000000000016001442795b177d2bd1d538d379af766a979e4056d43cd007000000000000160014f9e38ab4d13bc36fd4df0381e355d9f7b50d69808c106460" +
         "02" + // num_cets
         "0052" + // cet_0_len
         "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000ffffffff010acb0e000000000016001442795b177d2bd1d538d379af766a979e4056d43c00000000" +
         "0052" + // cet_1_len
-        "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000ffffffff010acb0e000000000016001442795b177d2bd1d538d379af766a979e4056d43c00000000"
+        "02000000017f19d63285e628c1b0702cd1a11df6fe4d2acc75595dc52fb8d2842b13aa56220000000000ffffffff010acb0e000000000016001442795b177d2bd1d538d379af766a979e4056d43c00000000" +
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         , "hex"
       ); // prettier-ignore
 
@@ -103,9 +105,7 @@ describe('DlcTransactionsV0', () => {
         const instance = unknownInstance as DlcTransactionsV0;
 
         expect(instance.fundTx.serialize()).to.deep.equal(fundTx.serialize());
-        expect(Number(instance.fundTxOutAmount)).to.deep.equal(
-          Number(fundTxOutAmount),
-        );
+        expect(Number(instance.fundTxVout)).to.deep.equal(Number(fundTxVout));
         expect(instance.refundTx.serialize()).to.deep.equal(
           refundTx.serialize(),
         );
@@ -123,7 +123,7 @@ describe('DlcTransactionsV0', () => {
 
       instance.contractId = contractId;
       instance.fundTx = fundTx;
-      instance.fundTxOutAmount = fundTxOutAmount;
+      instance.fundTxVout = fundTxVout;
       instance.refundTx = refundTx;
       instance.cets.push(cet0);
       instance.cets.push(cet1);

--- a/packages/rocksdb/lib/rocksdb-dlc-store.ts
+++ b/packages/rocksdb/lib/rocksdb-dlc-store.ts
@@ -137,6 +137,22 @@ export class RocksdbDlcStore extends RocksdbBase {
     await this._db.del(key);
   }
 
+  public async findDlcTransactionsList(): Promise<DlcTransactionsV0[]> {
+    return new Promise((resolve, reject) => {
+      const stream = this._db.createReadStream();
+      const results: DlcTransactionsV0[] = [];
+      stream.on('data', (data) => {
+        if (data.key[0] === Prefix.DlcAcceptV0) {
+          results.push(DlcTransactionsV0.deserialize(data.value));
+        }
+      });
+      stream.on('end', () => {
+        resolve(results);
+      });
+      stream.on('error', (err) => reject(err));
+    });
+  }
+
   public async findDlcTransactions(
     contractId: Buffer,
   ): Promise<DlcTransactionsV0> {


### PR DESCRIPTION
This PR makes modifications to the DlcTransactions object to include chain state

Specifically, it changes `fundTxOutAmount` to `fundTxVout` and adds:
- `fundEpoch` (hash and height)
- `fundBroadcastHeight`
- closeEpoch (hash and height)
- closeTxHash
- closeType (Execute, Refund, Mutual Close)
- closeBroadcastHeight