### PR TITLE
Generalize getOptionInfoFromOffer to allow OrderOffer and DlcOffer

### DIFF
--- a/packages/core/__tests__/dlc/finance/OptionInfo.spec.ts
+++ b/packages/core/__tests__/dlc/finance/OptionInfo.spec.ts
@@ -13,7 +13,7 @@ import { expect } from 'chai';
 import { CoveredCall } from '../../../lib/dlc/finance/CoveredCall';
 import {
   getOptionInfoFromContractInfo,
-  getOptionInfoFromDlcOffer,
+  getOptionInfoFromOffer,
 } from '../../../lib/dlc/finance/OptionInfo';
 
 describe('OptionInfo', () => {
@@ -66,7 +66,7 @@ describe('OptionInfo', () => {
     });
 
     it('should get correct OptionInfoWithPremium from DlcOffer', () => {
-      const optionInfo = getOptionInfoFromDlcOffer(dlcOffer);
+      const optionInfo = getOptionInfoFromOffer(dlcOffer);
 
       expect(optionInfo).to.deep.equal({
         contractSize,

--- a/packages/core/lib/dlc/finance/OptionInfo.ts
+++ b/packages/core/lib/dlc/finance/OptionInfo.ts
@@ -16,6 +16,18 @@ export interface OptionInfo {
   expiry: Date;
 }
 
+export type HasOfferCollateralSatoshis = {
+  offerCollateralSatoshis: bigint;
+};
+
+export type HasContractInfo = {
+  contractInfo: ContractInfo;
+};
+
+export type HasType = {
+  type: MessageType;
+};
+
 export function getOptionInfoFromContractInfo(
   _contractInfo: ContractInfo,
 ): OptionInfo {
@@ -54,16 +66,20 @@ export function getOptionInfoFromContractInfo(
   return { contractSize, strikePrice, expiry };
 }
 
-export function getOptionInfoFromDlcOffer(_dlcOffer: DlcOffer): OptionInfo {
-  if (_dlcOffer.type !== MessageType.DlcOfferV0)
-    throw Error('Only DlcOfferV0 currently supported');
+export function getOptionInfoFromOffer(
+  offer: HasOfferCollateralSatoshis & HasContractInfo & HasType,
+): OptionInfo {
+  if (
+    offer.type !== MessageType.DlcOfferV0 &&
+    offer.type !== MessageType.OrderOfferV0
+  )
+    throw Error('Only DlcOfferV0 and OrderOfferV0 currently supported');
 
-  const dlcOffer = _dlcOffer as DlcOfferV0;
   const premium =
-    dlcOffer.contractInfo.totalCollateral - dlcOffer.offerCollateralSatoshis;
+    offer.contractInfo.totalCollateral - offer.offerCollateralSatoshis;
 
   return {
-    ...getOptionInfoFromContractInfo(dlcOffer.contractInfo),
+    ...getOptionInfoFromContractInfo(offer.contractInfo),
     premium,
   };
 }

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -3,3 +3,4 @@ export * from './dlc/TxFinalizer';
 export * from './dlc/CETCalculator';
 export * from './dlc/HyperbolaPayoutCurve';
 export * from './dlc/finance/CoveredCall';
+export * from './dlc/finance/OptionInfo';


### PR DESCRIPTION
This PR generalizes `getOptionInfoFromOffer` to allow for `OrderOffer` or `DlcOffer` to be passed in. 