### PR TITLE
Small fixes to transport and rocksdb

### DIFF
--- a/packages/rocksdb/lib/index.ts
+++ b/packages/rocksdb/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './rocksdb-wallet-store';
 export * from './rocksdb-order-store';
 export * from './rocksdb-dlc-store';
+export * from './rocksdb-irc-store';

--- a/packages/rocksdb/lib/rocksdb-wallet-store.ts
+++ b/packages/rocksdb/lib/rocksdb-wallet-store.ts
@@ -1,4 +1,4 @@
-import { sha256 } from '@liquality/crypto';
+import { sha256 } from '@node-lightning/crypto';
 import { RocksdbBase } from '@node-lightning/gossip-rocksdb';
 import { AddressCache } from '@node-dlc/messaging';
 import Cryptr from 'cryptr';
@@ -33,10 +33,7 @@ export class RocksdbWalletStore extends RocksdbBase {
   }
 
   public async findSeed(apiKey: Buffer): Promise<string> {
-    const key = Buffer.concat([
-      Buffer.from([Prefix.Wallet]),
-      Buffer.from(sha256(apiKey), 'hex'),
-    ]);
+    const key = Buffer.concat([Buffer.from([Prefix.Wallet]), sha256(apiKey)]);
     const raw = await this._safeGet<Buffer>(key);
     if (!raw)
       throw new Error('Wallet has not been created or incorrect api key');
@@ -51,19 +48,13 @@ export class RocksdbWalletStore extends RocksdbBase {
     const cryptr = new Cryptr(apiKey.toString('hex'));
     const encryptedMnemonic = cryptr.encrypt(mnemonic);
     const value = Buffer.from(encryptedMnemonic, 'hex');
-    const key = Buffer.concat([
-      Buffer.from([Prefix.Wallet]),
-      Buffer.from(sha256(apiKey), 'hex'),
-    ]);
+    const key = Buffer.concat([Buffer.from([Prefix.Wallet]), sha256(apiKey)]);
     await this._db.put(key, value);
     await this.saveApiKeyHash(apiKey);
   }
 
   public async deleteSeed(apiKey: Buffer): Promise<void> {
-    const key = Buffer.concat([
-      Buffer.from([Prefix.Wallet]),
-      Buffer.from(sha256(apiKey), 'hex'),
-    ]);
+    const key = Buffer.concat([Buffer.from([Prefix.Wallet]), sha256(apiKey)]);
     await this._db.del(key);
   }
 
@@ -75,7 +66,7 @@ export class RocksdbWalletStore extends RocksdbBase {
   }
 
   public async saveApiKeyHash(apiKey: Buffer): Promise<void> {
-    const value = Buffer.from(sha256(apiKey), 'hex');
+    const value = sha256(apiKey);
     const key = Buffer.from([Prefix.ApiKey]);
     await this._db.put(key, value);
   }

--- a/packages/rocksdb/package-lock.json
+++ b/packages/rocksdb/package-lock.json
@@ -4,6 +4,14 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+			"integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"@dabh/diagnostics": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
@@ -14,6 +22,16 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"@liquality/bitcoin-networks": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.0.0-beta.2.tgz",
+			"integrity": "sha512-t40R9r8JlsDKtI7UF6IREVr51oK7K+UwHXAihLoZyWzi5uOQ6S5LKhs118GEN+81GDT7h7Wk/lEwgOMMaBDOgg==",
+			"requires": {
+				"@babel/runtime": "^7.12.1",
+				"@liquality/types": "^1.0.0-beta.2",
+				"bitcoinjs-lib": "^5.2.0"
+			}
+		},
 		"@liquality/crypto": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/@liquality/crypto/-/crypto-1.0.0-beta.2.tgz",
@@ -22,6 +40,35 @@
 				"bech32": "^1.1.3",
 				"bs58": "^4.0.1",
 				"crypto-hashing": "^1.0.0"
+			}
+		},
+		"@liquality/types": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@liquality/types/-/types-1.1.5.tgz",
+			"integrity": "sha512-PL+y2dXtXK4D4l8diDZjkKTLuyD0HwnLT1cEv1Lw8YE46DRG3nls7nasje91VsQTxrzVbMZUBiRs+naFHATyxA==",
+			"requires": {
+				"bignumber.js": "^9.0.1"
+			}
+		},
+		"@node-dlc/core": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/@node-dlc/core/-/core-0.4.5.tgz",
+			"integrity": "sha512-cYVuz6Yt3SsL0qvm+afyKS5dD+VdStLpA7421Al1E/c7UQaM6H3BKr3O32APoQtP+ulI+EHs0rkrZoEHgq3fvQ==",
+			"requires": {
+				"@node-dlc/messaging": "^0.4.5",
+				"@node-lightning/bitcoin": "0.22.1",
+				"@node-lightning/core": "0.22.1"
+			}
+		},
+		"@node-dlc/messaging": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/@node-dlc/messaging/-/messaging-0.4.5.tgz",
+			"integrity": "sha512-gaSZ0XBMzb5GfOX2NnQGsEcNgW2EhAWGhKQqy4S5WAZ/b+FqMtjFGLDXNde+4z/fFsyGTJnHmbHBYJ/r89q2oA==",
+			"requires": {
+				"@liquality/bitcoin-networks": "1.0.0-beta.2",
+				"@node-lightning/bitcoin": "0.22.1",
+				"@node-lightning/bufio": "0.22.1",
+				"bitcoinjs-lib": "5.2.0"
 			}
 		},
 		"@node-lightning/bitcoin": {
@@ -180,6 +227,45 @@
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
+		"bignumber.js": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"bip174": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
+			"integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
+		},
+		"bip32": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
+			"integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
+			"requires": {
+				"@types/node": "10.12.18",
+				"bs58check": "^2.1.1",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"tiny-secp256k1": "^1.1.3",
+				"typeforce": "^1.11.5",
+				"wif": "^2.0.6"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.12.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+					"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+				}
+			}
+		},
 		"bip39": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
@@ -190,6 +276,41 @@
 				"create-hash": "^1.1.0",
 				"pbkdf2": "^3.0.9",
 				"randombytes": "^2.0.1"
+			}
+		},
+		"bip66": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bitcoin-ops": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+			"integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+		},
+		"bitcoinjs-lib": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
+			"integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
+			"requires": {
+				"bech32": "^1.1.2",
+				"bip174": "^2.0.1",
+				"bip32": "^2.0.4",
+				"bip66": "^1.1.0",
+				"bitcoin-ops": "^1.4.0",
+				"bs58check": "^2.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.3",
+				"merkle-lib": "^2.0.10",
+				"pushdata-bitcoin": "^1.0.1",
+				"randombytes": "^2.0.1",
+				"tiny-secp256k1": "^1.1.1",
+				"typeforce": "^1.11.3",
+				"varuint-bitcoin": "^1.0.4",
+				"wif": "^2.0.1"
 			}
 		},
 		"bn.js": {
@@ -230,6 +351,16 @@
 			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 			"requires": {
 				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"buffer": {
@@ -367,7 +498,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -537,6 +667,11 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
 			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"finalhandler": {
 			"version": "1.1.2",
@@ -817,6 +952,11 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
+		"merkle-lib": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+			"integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
+		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -873,6 +1013,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"nan": {
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
 		},
 		"napi-macros": {
 			"version": "2.0.0",
@@ -962,6 +1107,14 @@
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
+		"pushdata-bitcoin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+			"integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+			"requires": {
+				"bitcoin-ops": "^1.3.0"
+			}
+		},
 		"qs": {
 			"version": "6.7.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -971,7 +1124,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -1006,6 +1158,11 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
 			"integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA=="
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"ripemd160": {
 			"version": "2.0.2",
@@ -1145,6 +1302,18 @@
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
 			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
 		},
+		"tiny-secp256k1": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+			"integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+			"requires": {
+				"bindings": "^1.3.0",
+				"bn.js": "^4.11.8",
+				"create-hmac": "^1.1.7",
+				"elliptic": "^6.4.0",
+				"nan": "^2.13.2"
+			}
+		},
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -1164,6 +1333,11 @@
 				"mime-types": "~2.1.24"
 			}
 		},
+		"typeforce": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1179,10 +1353,26 @@
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
+		"varuint-bitcoin": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+			"integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+			"requires": {
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"wif": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+			"integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+			"requires": {
+				"bs58check": "<3.0.0"
+			}
 		},
 		"winston": {
 			"version": "3.3.3",

--- a/packages/rocksdb/package.json
+++ b/packages/rocksdb/package.json
@@ -23,7 +23,6 @@
     "url": "git+https://github.com/atomicfinance/node-dlc.git"
   },
   "dependencies": {
-    "@liquality/crypto": "1.0.0-beta.2",
     "@node-dlc/core": "^0.4.5",
     "@node-dlc/messaging": "^0.4.5",
     "@node-lightning/bitcoin": "0.22.1",

--- a/packages/transport/lib/irc/ChannelType.ts
+++ b/packages/transport/lib/irc/ChannelType.ts
@@ -1,4 +1,6 @@
 export enum ChannelType {
   AtomicMarketPit = '#atomicmarket-pit',
+  TestnetMarketPit = '#testnetmarket-pit',
+  RegtestMarketPit = '#regtestmarket-pit',
   TestMarketPit = '#testmarket-pit',
 }

--- a/packages/transport/lib/irc/IrcManager.ts
+++ b/packages/transport/lib/irc/IrcManager.ts
@@ -102,7 +102,7 @@ export class IrcManager extends EventEmitter {
     this.logger = logger.sub('ircmgr');
     this.pubKey = pubKey;
     this.servers = servers;
-    this.nick = this.generateNick();
+    this.nick = this.generateNick(this.pubKey);
     this.channel = channel;
     this.opts = {
       port,
@@ -116,11 +116,11 @@ export class IrcManager extends EventEmitter {
     this.lengthNickMsgs = new Map<string, bigint>();
   }
 
-  public generateNick(): string {
+  public generateNick(pubKey: Buffer): string {
     const { type, version } = IrcManager;
     const prefix = `${type}${version}`;
     const suffix = Base58.encode(
-      sha256(this.pubKey).slice(0, IrcManager.nickHashLen),
+      sha256(pubKey).slice(0, IrcManager.nickHashLen),
     );
     return `${prefix}${suffix}`;
   }

--- a/packages/transport/package-lock.json
+++ b/packages/transport/package-lock.json
@@ -119,6 +119,12 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
+		"@types/node": {
+			"version": "14.14.45",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.45.tgz",
+			"integrity": "sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==",
+			"dev": true
+		},
 		"@types/standard-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@types/standard-error/-/standard-error-1.1.0.tgz",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@liquality/utils": "1.0.0-beta.2",
     "@node-lightning/logger": "0.22.1",
+    "@types/node": "^14.0.13",
     "fs": "0.0.1-security",
     "net": "1.0.2",
     "path": "0.12.7",


### PR DESCRIPTION
This PR fixes some small issues with transport and rocksdb

rocksdb:
- ensure rocksdb-irc-store is exported
- switch out @liquality/crypto for @node-lightning/crypto

transport:
- add TestnetMarketPit and RegtestMarketPit to `ChannelType`
- change generateNick to take pubkey as argument