### PR TITLE
Add node announcement to messaging and transport modules

### DIFF
--- a/packages/messaging/lib/messages/DlcMessage.ts
+++ b/packages/messaging/lib/messages/DlcMessage.ts
@@ -1,4 +1,5 @@
 import { BufferReader } from '@node-lightning/bufio';
+import { NodeAnnouncementMessage, MessageType as NodeLnMessageType } from '@node-lightning/wire';
 import { MessageType } from '../MessageType';
 import { ContractInfoV0, ContractInfoV1 } from './ContractInfo';
 import { DlcAcceptV0 } from './DlcAccept';
@@ -26,7 +27,8 @@ export abstract class DlcMessage {
     | DlcAcceptV0
     | DlcSignV0
     | OracleAttestationV0
-    | OracleAnnouncementV0 {
+    | OracleAnnouncementV0
+    | NodeAnnouncementMessage {
     const reader = new BufferReader(buf);
 
     const type = Number(reader.readUInt16BE());
@@ -50,6 +52,8 @@ export abstract class DlcMessage {
         return OracleAttestationV0.deserialize(buf);
       case MessageType.OracleAnnouncementV0:
         return OracleAnnouncementV0.deserialize(buf);
+      case NodeLnMessageType.NodeAnnouncement:
+        return NodeAnnouncementMessage.deserialize(buf);
       default:
         throw new Error(`Dlc Message type invalid`);
     }

--- a/packages/messaging/package-lock.json
+++ b/packages/messaging/package-lock.json
@@ -44,6 +44,21 @@
 			"resolved": "https://registry.npmjs.org/@node-lightning/bufio/-/bufio-0.22.1.tgz",
 			"integrity": "sha512-RsVS8J20qGva2QFZTnFFH93g/fOQ+qBm9APtRQI2VP+oWSICIarWrery83m1GKTzZ1IjpWbiiC9PHwdk6DkSsg=="
 		},
+		"@node-lightning/checksum": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/checksum/-/checksum-0.22.1.tgz",
+			"integrity": "sha512-5G3zxIuDVUUqQrWV6cxLAQ+Vvgm3CuF5G5I/jcELCqWTe7XKSDrbskVhwBq1fi6hQcGSMkiLRSeOZOs2r3/3hw=="
+		},
+		"@node-lightning/core": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/core/-/core-0.22.1.tgz",
+			"integrity": "sha512-pHdM1ZZYAacVQaZotkOuWG4ZUfVL0Ge3ZHkeZI30ur3czqEKqOhHrrZAf9In3i5WcK8RixuxohXy38nBpIz87w==",
+			"requires": {
+				"@node-lightning/bitcoin": "^0.22.1",
+				"@node-lightning/bufio": "^0.22.1",
+				"@node-lightning/crypto": "^0.22.1"
+			}
+		},
 		"@node-lightning/crypto": {
 			"version": "0.22.1",
 			"resolved": "https://registry.npmjs.org/@node-lightning/crypto/-/crypto-0.22.1.tgz",
@@ -55,8 +70,29 @@
 		"@node-lightning/logger": {
 			"version": "0.22.1",
 			"resolved": "https://registry.npmjs.org/@node-lightning/logger/-/logger-0.22.1.tgz",
-			"integrity": "sha512-1hyxsHF0un2kxnh49eiLbYsj5v6CY9fCL/aG+lay57hNaE2UbvbW5mCx1FdoKS5Y9KBAG4pZu61RfBdr7Adhpg==",
-			"dev": true
+			"integrity": "sha512-1hyxsHF0un2kxnh49eiLbYsj5v6CY9fCL/aG+lay57hNaE2UbvbW5mCx1FdoKS5Y9KBAG4pZu61RfBdr7Adhpg=="
+		},
+		"@node-lightning/noise": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/noise/-/noise-0.22.1.tgz",
+			"integrity": "sha512-bCHIWVrUZJ3UphMPtxDLpYcaMY4KyCqRCrJAuvbnt1LHZrllKHjsUZwXy9H0UL37vsHM4NxWPwmWl2Uj7NEaaw==",
+			"requires": {
+				"@node-lightning/crypto": "^0.22.1",
+				"@node-lightning/logger": "^0.22.1"
+			}
+		},
+		"@node-lightning/wire": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/wire/-/wire-0.22.1.tgz",
+			"integrity": "sha512-bTUlZ9c2iCaIBJGD8VuExgKS1T5ITx38DoSKOtBk61MOk4hyKfQFSIaUZQsjNtSiFaXl9hDOC75ycg2TKEIdLQ==",
+			"requires": {
+				"@node-lightning/bufio": "^0.22.1",
+				"@node-lightning/checksum": "^0.22.1",
+				"@node-lightning/core": "^0.22.1",
+				"@node-lightning/crypto": "^0.22.1",
+				"@node-lightning/logger": "^0.22.1",
+				"@node-lightning/noise": "^0.22.1"
+			}
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -25,6 +25,7 @@
     "@liquality/bitcoin-networks": "1.0.0-beta.2",
     "@node-lightning/bitcoin": "0.22.1",
     "@node-lightning/bufio": "0.22.1",
+    "@node-lightning/wire": "0.22.1",
     "bitcoinjs-lib": "5.2.0"
   },
   "devDependencies": {

--- a/packages/transport/package-lock.json
+++ b/packages/transport/package-lock.json
@@ -70,6 +70,21 @@
 			"resolved": "https://registry.npmjs.org/@node-lightning/bufio/-/bufio-0.22.1.tgz",
 			"integrity": "sha512-RsVS8J20qGva2QFZTnFFH93g/fOQ+qBm9APtRQI2VP+oWSICIarWrery83m1GKTzZ1IjpWbiiC9PHwdk6DkSsg=="
 		},
+		"@node-lightning/checksum": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/checksum/-/checksum-0.22.1.tgz",
+			"integrity": "sha512-5G3zxIuDVUUqQrWV6cxLAQ+Vvgm3CuF5G5I/jcELCqWTe7XKSDrbskVhwBq1fi6hQcGSMkiLRSeOZOs2r3/3hw=="
+		},
+		"@node-lightning/core": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/core/-/core-0.22.1.tgz",
+			"integrity": "sha512-pHdM1ZZYAacVQaZotkOuWG4ZUfVL0Ge3ZHkeZI30ur3czqEKqOhHrrZAf9In3i5WcK8RixuxohXy38nBpIz87w==",
+			"requires": {
+				"@node-lightning/bitcoin": "^0.22.1",
+				"@node-lightning/bufio": "^0.22.1",
+				"@node-lightning/crypto": "^0.22.1"
+			}
+		},
 		"@node-lightning/crypto": {
 			"version": "0.22.1",
 			"resolved": "https://registry.npmjs.org/@node-lightning/crypto/-/crypto-0.22.1.tgz",
@@ -81,8 +96,29 @@
 		"@node-lightning/logger": {
 			"version": "0.22.1",
 			"resolved": "https://registry.npmjs.org/@node-lightning/logger/-/logger-0.22.1.tgz",
-			"integrity": "sha512-1hyxsHF0un2kxnh49eiLbYsj5v6CY9fCL/aG+lay57hNaE2UbvbW5mCx1FdoKS5Y9KBAG4pZu61RfBdr7Adhpg==",
-			"dev": true
+			"integrity": "sha512-1hyxsHF0un2kxnh49eiLbYsj5v6CY9fCL/aG+lay57hNaE2UbvbW5mCx1FdoKS5Y9KBAG4pZu61RfBdr7Adhpg=="
+		},
+		"@node-lightning/noise": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/noise/-/noise-0.22.1.tgz",
+			"integrity": "sha512-bCHIWVrUZJ3UphMPtxDLpYcaMY4KyCqRCrJAuvbnt1LHZrllKHjsUZwXy9H0UL37vsHM4NxWPwmWl2Uj7NEaaw==",
+			"requires": {
+				"@node-lightning/crypto": "^0.22.1",
+				"@node-lightning/logger": "^0.22.1"
+			}
+		},
+		"@node-lightning/wire": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@node-lightning/wire/-/wire-0.22.1.tgz",
+			"integrity": "sha512-bTUlZ9c2iCaIBJGD8VuExgKS1T5ITx38DoSKOtBk61MOk4hyKfQFSIaUZQsjNtSiFaXl9hDOC75ycg2TKEIdLQ==",
+			"requires": {
+				"@node-lightning/bufio": "^0.22.1",
+				"@node-lightning/checksum": "^0.22.1",
+				"@node-lightning/core": "^0.22.1",
+				"@node-lightning/crypto": "^0.22.1",
+				"@node-lightning/logger": "^0.22.1",
+				"@node-lightning/noise": "^0.22.1"
+			}
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -29,6 +29,7 @@
     "@node-lightning/bitcoin": "0.22.1",
     "@node-lightning/bufio": "0.22.1",
     "@node-lightning/crypto": "0.22.1",
+    "@node-lightning/wire": "0.22.1",
     "irc": "0.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds `NodeAnnouncementMessage` from `@node-lightning/wire` to messaging and transport modules