### PR TITLE
Fix IrcManager msg len

### DIFF
--- a/packages/transport/lib/irc/IrcManager.ts
+++ b/packages/transport/lib/irc/IrcManager.ts
@@ -214,7 +214,10 @@ export class IrcManager extends EventEmitter {
     if (!length) length = BigInt(0);
 
     if (msgs.length === Number(length)) {
-      const msgBuf = Buffer.from(msg, 'hex');
+      const msgBuf = Buffer.from(
+        msg.length % 2 === 1 ? msg.slice(0, -1) : msg,
+        'hex',
+      );
       const reader = new BufferReader(msgBuf);
       length = reader.readBigSize();
       msgs = '';


### PR DESCRIPTION
This PR fixes IrcManager msg length calculation

(ensures it always gets even buffer)