### PR TITLE
Fix rocksdb oracle store to store by announcementId

### DIFF
--- a/packages/rocksdb/__tests__/rocksdb-oracle-store.spec.ts
+++ b/packages/rocksdb/__tests__/rocksdb-oracle-store.spec.ts
@@ -137,7 +137,10 @@ describe('RocksdbOracleStore', () => {
   const oracleNonces = new DlcIdsV0();
   oracleNonces.ids = nonces;
 
-  const eventId = 'Deribit-BTC-21MAY21';
+  const announcementId = Buffer.from(
+    '00b42522474be83e9863fc6fe287d3e9598260aef0f8b8c65b30a93cfd5f2602',
+    'hex',
+  );
 
   before(async () => {
     util.rmdir('.testdb');
@@ -184,13 +187,13 @@ describe('RocksdbOracleStore', () => {
 
   describe('save nonces', () => {
     it('should save nonces', async () => {
-      await sut.saveNonces(oracleNonces, eventId);
+      await sut.saveNonces(oracleNonces, announcementId);
     });
   });
 
   describe('find nonces', () => {
     it('should return the nonces object', async () => {
-      const actual = await sut.findNonces(eventId);
+      const actual = await sut.findNonces(announcementId);
 
       expect(actual.serialize()).to.deep.equal(oracleNonces.serialize());
     });
@@ -198,9 +201,9 @@ describe('RocksdbOracleStore', () => {
 
   describe('delete nonces', () => {
     it('should delete nonces', async () => {
-      await sut.deleteNonces(eventId);
+      await sut.deleteNonces(announcementId);
 
-      const actual = await sut.findNonces(eventId);
+      const actual = await sut.findNonces(announcementId);
       expect(actual).to.be.undefined;
     });
   });

--- a/packages/rocksdb/lib/rocksdb-oracle-store.ts
+++ b/packages/rocksdb/lib/rocksdb-oracle-store.ts
@@ -60,29 +60,32 @@ export class RocksdbOracleStore extends RocksdbBase {
     await this._db.del(key);
   }
 
-  public async findNonces(eventId: string): Promise<DlcIdsV0> {
+  public async findNonces(announcementId: Buffer): Promise<DlcIdsV0> {
     const key = Buffer.concat([
       Buffer.from([Prefix.OracleNoncesV0]),
-      Buffer.from(eventId),
+      announcementId,
     ]);
     const raw = await this._safeGet<Buffer>(key);
     if (!raw) return;
     return DlcIdsV0.deserialize(raw);
   }
 
-  public async saveNonces(nonces: DlcIdsV0, eventId: string): Promise<void> {
+  public async saveNonces(
+    nonces: DlcIdsV0,
+    announcementId: Buffer,
+  ): Promise<void> {
     const value = nonces.serialize();
     const key = Buffer.concat([
       Buffer.from([Prefix.OracleNoncesV0]),
-      Buffer.from(eventId),
+      announcementId,
     ]);
     await this._db.put(key, value);
   }
 
-  public async deleteNonces(eventId: string): Promise<void> {
+  public async deleteNonces(announcementId: Buffer): Promise<void> {
     const key = Buffer.concat([
       Buffer.from([Prefix.OracleNoncesV0]),
-      Buffer.from(eventId),
+      announcementId,
     ]);
     await this._db.del(key);
   }


### PR DESCRIPTION
This PR switches `RocksdbOracleStore` to find and save by `announcementId` instead of `eventId`

(`announcementId` is simply the hash of `OracleAnnouncement`)