### PR TITLE
Fix transaction get id in BlockWatcher

### DIFF
--- a/packages/chainmon/lib/BlockWatcher.ts
+++ b/packages/chainmon/lib/BlockWatcher.ts
@@ -100,8 +100,7 @@ export class BlockWatcher extends EventEmitter {
     const block = Block.fromBuffer(buf);
     let txs: [string];
     for (const transaction of block.transactions) {
-      const tx = Tx.fromBuffer(transaction.toBuffer());
-      if (!txs) txs = [tx.txId.toString()];
+      if (!txs) txs = [transaction.getId()];
     }
 
     const previousblockhash = Buffer.from(block.prevHash)


### PR DESCRIPTION
This PR fixes transaction get txid in BlockWatcher

Specifically @node-lightning/bitcoin is unable to parse coinbase tx `020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff15035f851e0427bfb8600134ea004d0000ff00000000ffffffff02338d9b000000000017a914f5fb634163aee17801523fbfaee93d4baa6cf383870000000000000000266a24aa21a9ed168ec184e411c5656583be8c3e750262343e9aa6dce0bcfd7fe6b51f6c9314a60120000000000000000000000000000000000000000000000000000000000000000000000000`

However bitcoinjs-lib has no issues

TODO: debug issue in @node-lightning