### PR TITLE
Fix IrcOrderManager privkey var name argument

### DIFF
--- a/packages/transport/lib/irc/IrcOrderManager.ts
+++ b/packages/transport/lib/irc/IrcOrderManager.ts
@@ -11,7 +11,7 @@ export class IrcOrderManager extends IrcManager {
 
   constructor(
     logger: ILogger,
-    pubKey: Buffer,
+    privKey: Buffer,
     servers = ['irc.darkscience.net'],
     debug = false,
     channel = ChannelType.AtomicMarketPit,
@@ -21,7 +21,7 @@ export class IrcOrderManager extends IrcManager {
   ) {
     super(
       logger,
-      pubKey,
+      privKey,
       servers,
       debug,
       channel,


### PR DESCRIPTION
This PR fixes a typo in `IrcOrderManager` where the argument name should've been privkey not pubkey