### PR TITLE
Add try catch for block parsing

### DIFF
--- a/packages/chainmon/lib/BlockWatcher.ts
+++ b/packages/chainmon/lib/BlockWatcher.ts
@@ -149,9 +149,16 @@ export class BlockWatcher extends EventEmitter {
     this.receivedBlocks.set(blockSummary.hash, blockSummary);
 
     for (const transaction of block.transactions) {
-      const tx = Tx.fromBuffer(transaction.toBuffer());
-      this._checkOutpoints(blockSummary, tx);
-      this._checkScriptPubkeys(blockSummary, tx);
+      try {
+        const tx = Tx.fromBuffer(transaction.toBuffer());
+        this._checkOutpoints(blockSummary, tx);
+        this._checkScriptPubkeys(blockSummary, tx);
+      } catch (e) {
+        console.log(
+          'Failed to deserialize tx',
+          transaction.toBuffer().toString('hex'),
+        );
+      }
     }
 
     const existingBlockWithPrevHash = this.previousHashToHash.get(


### PR DESCRIPTION
This PR adds a `try` `catch` around `_processBlock` in `BlockWatcher` to ensure transactions not supported by @node-lightning don't cause the watchter to throw. Specifically, @node-lightning doesn't yet support parsing coinbase transactions. 