### PR TITLE
Add missing field for DLC close

### DIFF
--- a/packages/messaging/__tests__/messages/DlcCloseV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcCloseV0.spec.ts
@@ -21,6 +21,7 @@ describe('DlcClose', () => {
 
   const offerPayoutSatoshis = Buffer.from('0000000005f5e100', 'hex');
   const acceptPayoutSatoshis = Buffer.from('0000000005f5e100', 'hex');
+  const fundInputSerialId = Buffer.from('00000000075bcd15', 'hex');
 
   const fundingInputsLen = Buffer.from('0001', 'hex');
   const fundingInputV0 = Buffer.from(
@@ -42,6 +43,7 @@ describe('DlcClose', () => {
     closeSignature,
     offerPayoutSatoshis,
     acceptPayoutSatoshis,
+    fundInputSerialId,
     fundingInputsLen,
     fundingInputV0,
   ]);
@@ -52,6 +54,7 @@ describe('DlcClose', () => {
     instance.closeSignature = closeSignature;
     instance.offerPayoutSatoshis = BigInt(100000000);
     instance.acceptPayoutSatoshis = BigInt(100000000);
+    instance.fundInputSerialId = BigInt(123456789);
     instance.fundingInputs = [FundingInputV0.deserialize(fundingInputV0)];
   });
 
@@ -86,6 +89,7 @@ describe('DlcClose', () => {
         expect(instance.closeSignature).to.deep.equal(closeSignature);
         expect(Number(instance.offerPayoutSatoshis)).to.equal(100000000);
         expect(Number(instance.acceptPayoutSatoshis)).to.equal(100000000);
+        expect(Number(instance.fundInputSerialId)).to.equal(123456789);
         expect(instance.fundingInputs[0].serialize().toString('hex')).to.equal(
           fundingInputV0.toString('hex'),
         );
@@ -103,6 +107,9 @@ describe('DlcClose', () => {
         const json = instance.toJSON();
         expect(json.contractId).to.equal(contractId.toString('hex'));
         expect(json.closeSignature).to.equal(closeSignature.toString('hex'));
+        expect(json.fundInputSerialId).to.equal(
+          Number(fundInputSerialId.readBigInt64BE()),
+        );
         expect(json.fundingInputs[0].prevTx).to.equal(
           instance.fundingInputs[0].prevTx.serialize().toString('hex'),
         );

--- a/packages/messaging/lib/messages/DlcClose.ts
+++ b/packages/messaging/lib/messages/DlcClose.ts
@@ -46,6 +46,7 @@ export class DlcCloseV0 extends DlcClose implements IDlcMessage {
     instance.closeSignature = reader.readBytes(64);
     instance.offerPayoutSatoshis = reader.readUInt64BE();
     instance.acceptPayoutSatoshis = reader.readUInt64BE();
+    instance.fundInputSerialId = reader.readUInt64BE();
     const fundingInputsLen = reader.readUInt16BE();
     for (let i = 0; i < fundingInputsLen; i++) {
       instance.fundingInputs.push(FundingInputV0.deserialize(getTlv(reader)));
@@ -67,6 +68,8 @@ export class DlcCloseV0 extends DlcClose implements IDlcMessage {
 
   public acceptPayoutSatoshis: bigint;
 
+  public fundInputSerialId: bigint;
+
   public fundingInputs: FundingInputV0[] = [];
 
   /**
@@ -79,6 +82,7 @@ export class DlcCloseV0 extends DlcClose implements IDlcMessage {
     writer.writeBytes(this.closeSignature);
     writer.writeUInt64BE(this.offerPayoutSatoshis);
     writer.writeUInt64BE(this.acceptPayoutSatoshis);
+    writer.writeUInt64BE(this.fundInputSerialId);
     writer.writeUInt16BE(this.fundingInputs.length);
 
     for (const fundingInput of this.fundingInputs) {
@@ -118,6 +122,7 @@ export class DlcCloseV0 extends DlcClose implements IDlcMessage {
       closeSignature: this.closeSignature.toString('hex'),
       offerPayoutSatoshis: Number(this.offerPayoutSatoshis),
       acceptPayoutSatoshis: Number(this.acceptPayoutSatoshis),
+      fundInputSerialId: Number(this.fundInputSerialId),
       fundingInputs: this.fundingInputs.map((input) => input.toJSON()),
     };
   }
@@ -129,5 +134,6 @@ export interface IDlcCloseV0JSON {
   closeSignature: string;
   offerPayoutSatoshis: number;
   acceptPayoutSatoshis: number;
+  fundInputSerialId: number;
   fundingInputs: IFundingInputV0JSON[];
 }


### PR DESCRIPTION
Add `fund_input_serial_id` field as described in https://github.com/discreetlogcontracts/dlcspecs/pull/170