### PR TITLE
Add OrderMetadata for providing additional info about order liquidity

### DIFF
--- a/packages/messaging/__tests__/messages/OrderOffer.spec.ts
+++ b/packages/messaging/__tests__/messages/OrderOffer.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { ContractInfo } from '../../lib/messages/ContractInfo';
+import { OrderMetadataV0 } from '../../lib/messages/OrderMetadata';
 import { OrderOfferV0 } from '../../lib/messages/OrderOffer';
 
 describe('OrderOffer', () => {
@@ -10,55 +11,55 @@ describe('OrderOffer', () => {
   );
 
   describe('serialize', () => {
+    const instance = new OrderOfferV0();
+
+    instance.chainHash = chainHash;
+
+    instance.contractInfo = ContractInfo.deserialize(
+      Buffer.from(
+        'fdd82e' + // type contract_info
+          'fd0131' + // length
+          '000000000bebc200' + // total_collateral
+          'fda710' + // type contract_descriptor
+          '79' + // length
+          '03' + // num_outcomes
+          'c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722' + // outcome_1
+          '0000000000000000' + // payout_1
+          'adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead' + // outcome_2
+          '00000000092363a3' + // payout_2
+          '6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288' + // outcome_3
+          '000000000bebc200' + // payout_3
+          'fda712' + // type oracle_info
+          'a8' + // length
+          'fdd824' + // type oracle_announcement
+          'a4' + // length
+          'fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9' + // announcement_signature_r
+          '494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4' + // announcement_signature_s
+          'da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b' + // oracle_public_key
+          'fdd822' + // type oracle_event
+          '40' + // length
+          '0001' + // nb_nonces
+          '3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b' + // oracle_nonces
+          '00000000' + // event_maturity_epoch
+          'fdd806' + // type enum_event_descriptor
+          '10' + // length
+          '0002' + // num_outcomes
+          '06' + // outcome_1_len
+          '64756d6d7931' + // outcome_1
+          '06' + // outcome_2_len
+          '64756d6d7932' + // outcome_2
+          '05' + // event_id_length
+          '64756d6d79', // event_id
+        'hex',
+      ),
+    );
+
+    instance.offerCollateralSatoshis = BigInt(100000000);
+    instance.feeRatePerVb = BigInt(1);
+    instance.cetLocktime = 100;
+    instance.refundLocktime = 200;
+
     it('serializes', () => {
-      const instance = new OrderOfferV0();
-
-      instance.chainHash = chainHash;
-
-      instance.contractInfo = ContractInfo.deserialize(
-        Buffer.from(
-          'fdd82e' + // type contract_info
-            'fd0131' + // length
-            '000000000bebc200' + // total_collateral
-            'fda710' + // type contract_descriptor
-            '79' + // length
-            '03' + // num_outcomes
-            'c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722' + // outcome_1
-            '0000000000000000' + // payout_1
-            'adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead' + // outcome_2
-            '00000000092363a3' + // payout_2
-            '6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288' + // outcome_3
-            '000000000bebc200' + // payout_3
-            'fda712' + // type oracle_info
-            'a8' + // length
-            'fdd824' + // type oracle_announcement
-            'a4' + // length
-            'fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9' + // announcement_signature_r
-            '494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4' + // announcement_signature_s
-            'da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b' + // oracle_public_key
-            'fdd822' + // type oracle_event
-            '40' + // length
-            '0001' + // nb_nonces
-            '3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b' + // oracle_nonces
-            '00000000' + // event_maturity_epoch
-            'fdd806' + // type enum_event_descriptor
-            '10' + // length
-            '0002' + // num_outcomes
-            '06' + // outcome_1_len
-            '64756d6d7931' + // outcome_1
-            '06' + // outcome_2_len
-            '64756d6d7932' + // outcome_2
-            '05' + // event_id_length
-            '64756d6d79', // event_id
-          'hex',
-        ),
-      );
-
-      instance.offerCollateralSatoshis = BigInt(100000000);
-      instance.feeRatePerVb = BigInt(1);
-      instance.cetLocktime = 100;
-      instance.refundLocktime = 200;
-
       expect(instance.serialize().toString("hex")).to.equal(
         "f532" + // type
         "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f" + // chain_hash
@@ -101,11 +102,14 @@ describe('OrderOffer', () => {
         "000000c8" // refund_locktime
       ); // prettier-ignore
     });
-  });
 
-  describe('deserialize', () => {
-    it('deserializes', () => {
-      const buf = Buffer.from(
+    it('serializes with metadata', () => {
+      const metadata = new OrderMetadataV0();
+      metadata.offerId = 'strategy-88';
+
+      instance.metadata = metadata;
+
+      expect(instance.serialize().toString('hex')).to.equal(
         "f532" + // type
         "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f" + // chain_hash
         "fdd82e" + // type contract_info
@@ -144,10 +148,57 @@ describe('OrderOffer', () => {
         "0000000005f5e100" + // total_collateral_satoshis
         "0000000000000001" + // fee_rate_per_vb
         "00000064" + // cet_locktime
-        "000000c8" // refund_locktime
-        , "hex"
+        "000000c8" + // refund_locktime
+        "fdf5360c0b73747261746567792d3838" // order_metadata_v0 tlv
       ); // prettier-ignore
+    });
+  });
 
+  describe('deserialize', () => {
+    const buf = Buffer.from(
+      "f532" + // type
+      "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f" + // chain_hash
+      "fdd82e" + // type contract_info
+      "fd0131" + // length
+      "000000000bebc200" + // total_collateral
+      "fda710" + // type contract_descriptor
+      "79" + // length
+      "03" + // num_outcomes
+      "c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722" + // outcome_1
+      "0000000000000000" + // payout_1
+      "adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead" + // outcome_2
+      "00000000092363a3" + // payout_2
+      "6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288" + // outcome_3
+      "000000000bebc200" + // payout_3
+      "fda712" + // type oracle_info
+      "a8" + // length
+      "fdd824" + // type oracle_announcement
+      "a4" + // length
+      "fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9" + // announcement_signature_r
+      "494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4" + // announcement_signature_s
+      "da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b" + // oracle_public_key
+      "fdd822" + // type oracle_event
+      "40" + // length
+      "0001" + // nb_nonces
+      "3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b" + // oracle_nonces
+      "00000000" + // event_maturity_epoch
+      "fdd806" + // type enum_event_descriptor
+      "10" + // length
+      "0002" + // num_outcomes
+      "06" + // outcome_1_len
+      "64756d6d7931" + // outcome_1
+      "06" + // outcome_2_len
+      "64756d6d7932" + // outcome_2
+      "05" + // event_id_length
+      "64756d6d79" + // event_id
+      "0000000005f5e100" + // total_collateral_satoshis
+      "0000000000000001" + // fee_rate_per_vb
+      "00000064" + // cet_locktime
+      "000000c8" // refund_locktime
+      , "hex"
+    ); // prettier-ignore
+
+    it('deserializes', () => {
       const instance = OrderOfferV0.deserialize(buf);
 
       expect(instance.chainHash).to.deep.equal(chainHash);
@@ -190,6 +241,19 @@ describe('OrderOffer', () => {
       expect(Number(instance.feeRatePerVb)).to.equal(1);
       expect(instance.cetLocktime).to.equal(100);
       expect(instance.refundLocktime).to.equal(200);
+    });
+
+    it('deserializes with metadata', () => {
+      const bufWithMetadata = Buffer.concat([
+        buf,
+        Buffer.from('fdf5360c0b73747261746567792d3838', 'hex'),
+      ]);
+
+      const instance = OrderOfferV0.deserialize(bufWithMetadata);
+
+      expect((instance.metadata as OrderMetadataV0).offerId).to.equal(
+        'strategy-88',
+      );
     });
   });
 });

--- a/packages/messaging/lib/MessageType.ts
+++ b/packages/messaging/lib/MessageType.ts
@@ -65,6 +65,7 @@ export enum MessageType {
    */
   OrderOfferV0 = 62770,
   OrderAcceptV0 = 62772,
+  OrderMetadataV0 = 62774,
 
   OrderNegotiationFieldsV0 = 65334,
   OrderNegotiationFieldsV1 = 65336,

--- a/packages/messaging/lib/messages/OrderMetadata.ts
+++ b/packages/messaging/lib/messages/OrderMetadata.ts
@@ -1,0 +1,96 @@
+import { BufferReader, BufferWriter } from '@node-lightning/bufio';
+
+import { MessageType } from '../MessageType';
+import { IDlcMessage } from './DlcMessage';
+
+export abstract class OrderMetadata {
+  public static deserialize(buf: Buffer): OrderMetadata {
+    const reader = new BufferReader(buf);
+
+    const type = Number(reader.readUInt16BE());
+
+    switch (type) {
+      case MessageType.OrderMetadataV0:
+        return OrderMetadataV0.deserialize(buf);
+      default:
+        throw new Error(`Order metadata TLV type must be OrderMetadataV0`);
+    }
+  }
+
+  public abstract type: number;
+
+  public abstract toJSON(): IOrderMetadataJSON;
+
+  public abstract serialize(): Buffer;
+}
+
+/**
+ * OrderMetadata message contains information about a node and indicates its
+ * desire to enter into a new contract. This is the first step toward
+ * order negotiation.
+ */
+export class OrderMetadataV0 extends OrderMetadata implements IDlcMessage {
+  public static type = MessageType.OrderMetadataV0;
+
+  /**
+   * Deserializes an offer_dlc_v0 message
+   * @param buf
+   */
+  public static deserialize(buf: Buffer): OrderMetadataV0 {
+    const instance = new OrderMetadataV0();
+    const reader = new BufferReader(buf);
+
+    reader.readBigSize(); // read type
+    instance.length = reader.readBigSize();
+    const offerIdLength = reader.readBigSize();
+    const offerIdBuf = reader.readBytes(Number(offerIdLength));
+    instance.offerId = offerIdBuf.toString();
+
+    return instance;
+  }
+
+  /**
+   * The type for order_metadata_v0 message. order_metadata_v0 = 62774
+   */
+  public type = OrderMetadataV0.type;
+
+  public length: bigint;
+
+  /**
+   * offerId is a unique identifier for an offer
+   * It can be used for updating liquidity for a particular category
+   * For example, how much liquidity is remaining for a particular strategy
+   * which a market maker is providing liquidity for
+   */
+  public offerId: string;
+
+  /**
+   * Converts order_metadata_v0 to JSON
+   */
+  public toJSON(): IOrderMetadataJSON {
+    return {
+      offerId: this.offerId,
+    };
+  }
+
+  /**
+   * Serializes the oracle_event message into a Buffer
+   */
+  public serialize(): Buffer {
+    const writer = new BufferWriter();
+    writer.writeBigSize(this.type);
+
+    const dataWriter = new BufferWriter();
+    dataWriter.writeBigSize(this.offerId.length);
+    dataWriter.writeBytes(Buffer.from(this.offerId));
+
+    writer.writeBigSize(dataWriter.size);
+    writer.writeBytes(dataWriter.toBuffer());
+
+    return writer.toBuffer();
+  }
+}
+
+export interface IOrderMetadataJSON {
+  offerId: string;
+}


### PR DESCRIPTION
This PR adds `OrderMetadata` for providing additional info about order liquidity. `OrderMetadata` is a TLV with type number `62774`

This essentially changes `OrderOffer` to the following format

1. type: 62770 (`offer_order_v0`)
2. data:
   * [`chain_hash`:`chain_hash`]
   * [`contract_info`:`contract_info`]
   * [`u64`:`offer_collateral_satoshis`]
   * [`u64`:`feerate_per_vb`]
   * [`u32`:`cet_locktime`]
   * [`u32`:`refund_locktime`]
   * [`order_tlvs`: `tlvs`]