### PR TITLE
Add efficient find num dlc msgs rocksdb

### DIFF
--- a/packages/messaging/lib/MessageType.ts
+++ b/packages/messaging/lib/MessageType.ts
@@ -54,6 +54,7 @@ export enum MessageType {
    */
   DlcTransactionsV0 = 61230,
   DlcIdsV0 = 61232,
+  DlcInfoV0 = 61234,
 
   /**
    * Oracle Identifier

--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -12,6 +12,7 @@ export * from './messages/DlcCancel';
 export * from './messages/DlcClose';
 export * from './messages/DlcCloseMetadata';
 export * from './messages/DlcIds';
+export * from './messages/DlcInfo';
 export * from './messages/DlcMessage';
 export * from './messages/DlcOffer';
 export * from './messages/DlcSign';

--- a/packages/messaging/lib/messages/DlcInfo.ts
+++ b/packages/messaging/lib/messages/DlcInfo.ts
@@ -1,0 +1,83 @@
+import { BufferReader, BufferWriter } from '@node-lightning/bufio';
+
+import { MessageType } from '../MessageType';
+import { IDlcMessage } from './DlcMessage';
+
+export abstract class DlcInfo {
+  public static deserialize(buf: Buffer): DlcInfoV0 {
+    const reader = new BufferReader(buf);
+
+    const type = Number(reader.readUInt16BE());
+
+    switch (type) {
+      case MessageType.DlcInfoV0:
+        return DlcInfoV0.deserialize(buf);
+      default:
+        throw new Error(`DLC IDs message type must be DlcInfoV0`);
+    }
+  }
+
+  public abstract type: number;
+
+  public abstract serialize(): Buffer;
+}
+
+/**
+ * DlcInfo message contains list of buffers
+ */
+export class DlcInfoV0 extends DlcInfo implements IDlcMessage {
+  public static type = MessageType.DlcInfoV0;
+
+  /**
+   * Deserializes an dlc_ids_v0 message
+   * @param buf
+   */
+  public static deserialize(buf: Buffer): DlcInfoV0 {
+    const instance = new DlcInfoV0();
+    const reader = new BufferReader(buf);
+
+    reader.readUInt16BE(); // read type
+
+    instance.numDlcOffers = reader.readUInt32BE();
+    instance.numDlcAccepts = reader.readUInt32BE();
+    instance.numDlcSigns = reader.readUInt32BE();
+    instance.numDlcCancels = reader.readUInt32BE();
+    instance.numDlcCloses = reader.readUInt32BE();
+    instance.numDlcTransactions = reader.readUInt32BE();
+
+    return instance;
+  }
+
+  /**
+   * The type for dlc_info_v0 message
+   */
+  public type = DlcInfoV0.type;
+
+  public numDlcOffers: number;
+
+  public numDlcAccepts: number;
+
+  public numDlcSigns: number;
+
+  public numDlcCancels: number;
+
+  public numDlcCloses: number;
+
+  public numDlcTransactions: number;
+
+  /**
+   * Serializes the dlc_info_v0 message into a Buffer
+   */
+  public serialize(): Buffer {
+    const writer = new BufferWriter();
+    writer.writeUInt16BE(this.type);
+    writer.writeUInt32BE(this.numDlcOffers);
+    writer.writeUInt32BE(this.numDlcAccepts);
+    writer.writeUInt32BE(this.numDlcSigns);
+    writer.writeUInt32BE(this.numDlcCancels);
+    writer.writeUInt32BE(this.numDlcCloses);
+    writer.writeUInt32BE(this.numDlcTransactions);
+
+    return writer.toBuffer();
+  }
+}

--- a/packages/messaging/lib/messages/DlcTransactions.ts
+++ b/packages/messaging/lib/messages/DlcTransactions.ts
@@ -30,9 +30,8 @@ export abstract class DlcTransactions {
 }
 
 /**
- * DlcOffer message contains information about a node and indicates its
- * desire to enter into a new contract. This is the first step toward
- * creating the funding transaction and CETs.
+ * DlcTransactions message contains information about state of DLC
+ * contract such as fundtx and closetx
  */
 export class DlcTransactionsV0 extends DlcTransactions implements IDlcMessage {
   public static type = MessageType.DlcTransactionsV0;

--- a/packages/rocksdb/__tests__/rocksdb-dlc-store.spec.ts
+++ b/packages/rocksdb/__tests__/rocksdb-dlc-store.spec.ts
@@ -243,6 +243,13 @@ describe('RocksdbDlcStore', () => {
     });
   });
 
+  describe('find num_dlc_offer', () => {
+    it('should return the num_dlc_offer', async () => {
+      const numDlcOffers = await sut.findNumDlcOffers();
+      expect(numDlcOffers).to.equal(1);
+    });
+  });
+
   describe('delete dlc_offer', () => {
     it('should delete dlc_offer', async () => {
       const tempContractId = sha256(dlcOfferHex);
@@ -287,6 +294,13 @@ describe('RocksdbDlcStore', () => {
     });
   });
 
+  describe('find num_dlc_accept', () => {
+    it('should return the num_dlc_accept', async () => {
+      const numDlcAccepts = await sut.findNumDlcAccepts();
+      expect(numDlcAccepts).to.equal(1);
+    });
+  });
+
   describe('delete dlc_offer', () => {
     it('should delete dlc_offer', async () => {
       await sut.deleteDlcOffer(contractId);
@@ -306,6 +320,13 @@ describe('RocksdbDlcStore', () => {
     it('should return the dlc_sign object', async () => {
       const actual = await sut.findDlcSign(dlcSign.contractId);
       expect(actual).to.deep.equal(dlcSign);
+    });
+  });
+
+  describe('find num_dlc_sign', () => {
+    it('should return the num_dlc_sign', async () => {
+      const numDlcSigns = await sut.findNumDlcSigns();
+      expect(numDlcSigns).to.equal(1);
     });
   });
 
@@ -398,6 +419,13 @@ describe('RocksdbDlcStore', () => {
       expect(actual.fundTx.serialize()).to.deep.equal(
         dlcTxs.fundTx.serialize(),
       );
+    });
+  });
+
+  describe('find num_dlc_transactions', () => {
+    it('should return the num_dlc_transactions', async () => {
+      const numDlcTxs = await sut.findNumDlcTransactionsList();
+      expect(numDlcTxs).to.equal(1);
     });
   });
 

--- a/packages/rocksdb/__tests__/rocksdb-info-store.spec.ts
+++ b/packages/rocksdb/__tests__/rocksdb-info-store.spec.ts
@@ -1,0 +1,57 @@
+// tslint:disable: no-unused-expression
+
+import { DlcInfoV0 } from '@node-dlc/messaging';
+import { expect } from 'chai';
+
+import { RocksdbInfoStore } from '../lib/rocksdb-info-store';
+import * as util from './rocksdb';
+
+describe('RocksdbDlcStore', () => {
+  let sut: RocksdbInfoStore;
+
+  const dlcInfoHex = Buffer.from(
+    "ef32" + // type
+    "0000000a" + // num dlc offers
+    "00000009" + // num dlc accepts
+    "00000009" + // num dlc signs
+    "00000004" + // num dlc cancels
+    "00000004" + // num dlc closes
+    "00000009" // num dlc transactions
+    , "hex"
+  ); // prettier-ignore
+
+  const dlcInfo = DlcInfoV0.deserialize(dlcInfoHex);
+
+  before(async () => {
+    util.rmdir('.testdb');
+    sut = new RocksdbInfoStore('./.testdb/nested/dir');
+    await sut.open();
+  });
+
+  after(async () => {
+    await sut.close();
+    util.rmdir('.testdb');
+  });
+
+  describe('save dlc_info', () => {
+    it('should save dlc_info', async () => {
+      await sut.saveDlcInfo(dlcInfo);
+    });
+  });
+
+  describe('find dlc_info', () => {
+    it('should return the dlc_info object', async () => {
+      const actual = await sut.findDlcInfo();
+      expect(actual).to.deep.equal(dlcInfo);
+    });
+  });
+
+  describe('delete dlc_info', () => {
+    it('should delete dlc_info', async () => {
+      await sut.deleteDlcInfo();
+
+      const actual = await sut.findDlcInfo();
+      expect(actual).to.be.undefined;
+    });
+  });
+});

--- a/packages/rocksdb/lib/rocksdb-dlc-store.ts
+++ b/packages/rocksdb/lib/rocksdb-dlc-store.ts
@@ -40,6 +40,20 @@ export class RocksdbDlcStore extends RocksdbBase {
     });
   }
 
+  public async findNumDlcOffers(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const stream = this._db.createReadStream();
+      let num = 0;
+      stream.on('data', (data) => {
+        if (data.key[0] === Prefix.DlcOfferV0) num++;
+      });
+      stream.on('end', () => {
+        resolve(num);
+      });
+      stream.on('error', (err) => reject(err));
+    });
+  }
+
   public async findDlcOffer(tempContractId: Buffer): Promise<DlcOfferV0> {
     const key = Buffer.concat([
       Buffer.from([Prefix.DlcOfferV0]),
@@ -79,6 +93,20 @@ export class RocksdbDlcStore extends RocksdbBase {
       });
       stream.on('end', () => {
         resolve(results);
+      });
+      stream.on('error', (err) => reject(err));
+    });
+  }
+
+  public async findNumDlcAccepts(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const stream = this._db.createReadStream();
+      let num = 0;
+      stream.on('data', (data) => {
+        if (data.key[0] === Prefix.DlcAcceptV0) num++;
+      });
+      stream.on('end', () => {
+        resolve(num);
       });
       stream.on('error', (err) => reject(err));
     });
@@ -144,6 +172,20 @@ export class RocksdbDlcStore extends RocksdbBase {
       });
       stream.on('end', () => {
         resolve(results);
+      });
+      stream.on('error', (err) => reject(err));
+    });
+  }
+
+  public async findNumDlcSigns(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const stream = this._db.createReadStream();
+      let num = 0;
+      stream.on('data', (data) => {
+        if (data.key[0] === Prefix.DlcSignV0) num++;
+      });
+      stream.on('end', () => {
+        resolve(num);
       });
       stream.on('error', (err) => reject(err));
     });
@@ -257,6 +299,20 @@ export class RocksdbDlcStore extends RocksdbBase {
       });
       stream.on('end', () => {
         resolve(results);
+      });
+      stream.on('error', (err) => reject(err));
+    });
+  }
+
+  public async findNumDlcTransactionsList(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const stream = this._db.createReadStream();
+      let num = 0;
+      stream.on('data', (data) => {
+        if (data.key[0] === Prefix.DlcTransactionsV0) num++;
+      });
+      stream.on('end', () => {
+        resolve(num);
       });
       stream.on('error', (err) => reject(err));
     });

--- a/packages/rocksdb/lib/rocksdb-info-store.ts
+++ b/packages/rocksdb/lib/rocksdb-info-store.ts
@@ -1,0 +1,26 @@
+import { DlcInfoV0 } from '@node-dlc/messaging';
+import { RocksdbBase } from '@node-lightning/gossip-rocksdb';
+
+enum Prefix {
+  DlcInfoV0 = 90,
+}
+
+export class RocksdbInfoStore extends RocksdbBase {
+  public async findDlcInfo(): Promise<DlcInfoV0> {
+    const key = Buffer.concat([Buffer.from([Prefix.DlcInfoV0])]);
+    const raw = await this._safeGet<Buffer>(key);
+    if (!raw) return;
+    return DlcInfoV0.deserialize(raw);
+  }
+
+  public async saveDlcInfo(dlcInfo: DlcInfoV0): Promise<void> {
+    const value = dlcInfo.serialize();
+    const key = Buffer.concat([Buffer.from([Prefix.DlcInfoV0])]);
+    await this._db.put(key, value);
+  }
+
+  public async deleteDlcInfo(): Promise<void> {
+    const key = Buffer.concat([Buffer.from([Prefix.DlcInfoV0])]);
+    await this._db.del(key);
+  }
+}


### PR DESCRIPTION
This PR adds the ability to efficiently `findNumDlcOffers`, `findNumDlcAccepts`, `findNumDlcSigns`, `findNumDlcTransactions`

It also adds a new message type `DlcInfo` which can be used for storing latest number of messages for fast query