### PR TITLE
Add type to getOptionInfo response

### DIFF
--- a/packages/core/__tests__/dlc/finance/OptionInfo.spec.ts
+++ b/packages/core/__tests__/dlc/finance/OptionInfo.spec.ts
@@ -52,6 +52,7 @@ describe('OptionInfo', () => {
         contractSize,
         strikePrice,
         expiry,
+        type: 'call',
       });
     });
 
@@ -63,6 +64,7 @@ describe('OptionInfo', () => {
         strikePrice,
         expiry,
         premium,
+        type: 'call',
       });
     });
 
@@ -134,6 +136,7 @@ describe('OptionInfo', () => {
         contractSize,
         strikePrice,
         expiry,
+        type: 'put',
       });
     });
 
@@ -145,6 +148,7 @@ describe('OptionInfo', () => {
         strikePrice,
         expiry,
         premium,
+        type: 'put',
       });
     });
 

--- a/packages/core/lib/dlc/finance/OptionInfo.ts
+++ b/packages/core/lib/dlc/finance/OptionInfo.ts
@@ -17,6 +17,7 @@ export interface OptionInfo {
   contractSize: bigint;
   strikePrice: bigint;
   premium?: bigint;
+  type?: OptionType;
   expiry: Date;
 }
 
@@ -31,6 +32,8 @@ export type HasContractInfo = {
 export type HasType = {
   type: MessageType;
 };
+
+export type OptionType = 'put' | 'call';
 
 export function getOptionInfoFromContractInfo(
   _contractInfo: ContractInfo,
@@ -107,13 +110,14 @@ export function getOptionInfoFromContractInfo(
         oracleBase,
         oracleDigits,
       );
+  const type = isAscending ? 'put' : 'call';
 
   if (!curve.equals(sanityCurve))
     throw new Error(
       'Payout curve built from extracted OptionInfo does not match original payout curve',
     );
 
-  return { contractSize, strikePrice, expiry };
+  return { contractSize, strikePrice, expiry, type };
 }
 
 export function getOptionInfoFromOffer(

--- a/packages/messaging/lib/chain/ChainManager.ts
+++ b/packages/messaging/lib/chain/ChainManager.ts
@@ -34,7 +34,7 @@ export interface ILogger {
  */
 export class ChainManager extends EventEmitter {
   public blockHeight: number;
-  public started: boolean;
+  public started = false;
   public syncState: SyncState;
   public isSynchronizing: boolean;
   public chainClient: IChainFilterChainClient;
@@ -282,7 +282,7 @@ export class ChainManager extends EventEmitter {
             'Invalid tx for validating closing utxo: %s',
             transaction.toHex(),
           );
-          this.logger.error('Error: ', e);
+          this.logger.trace('Error: ', e);
         }
       }
 


### PR DESCRIPTION
This PR adds option `type` for `getOptionInfoFromContractInfo` response