### PR TITLE
Improve logger with error object passed on write

### DIFF
--- a/packages/logger/__tests__/logger/logger.spec.ts
+++ b/packages/logger/__tests__/logger/logger.spec.ts
@@ -137,6 +137,26 @@ describe('Logger', () => {
         debug('testing');
         expect((transport.write as sinon.SinonSpy).called).to.be.true;
       });
+
+      it('should pass and format errors', () => {
+        sut[fn]('testing', Error('error'));
+        expect((transport.write as sinon.SinonSpy).args[0][2]).to.be.instanceOf(
+          Error,
+        );
+        expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(
+          / Error: error/,
+        );
+        // Expect stack trace for LogLevel Trace
+        if (fn === 'trace') {
+          expect((transport.write as sinon.SinonSpy).args[0][0]).to.match(
+            /logger.spec.ts/,
+          );
+        } else {
+          expect((transport.write as sinon.SinonSpy).args[0][0]).not.to.match(
+            /logger.spec.ts/,
+          );
+        }
+      });
     });
   }
 });

--- a/packages/logger/lib/transport.ts
+++ b/packages/logger/lib/transport.ts
@@ -1,5 +1,5 @@
 import { LogLevel } from './log-level';
 
 export interface ITransport {
-  write(line: string, level?: LogLevel): void;
+  write(line: string, level?: LogLevel, error?: Error): void;
 }


### PR DESCRIPTION
This PR improves logger with an error object passed on write. This allows for error-capturing libs to capture exceptions easily. 

For example, it could be used by a `sentryTransport` to `captureException` providing a better error and stack trace

i.e.
```
export class SentryTransport implements ITransport {
  public write(line: string, level?: LogLevel, error?: Error): void {
    switch (level) {
      case LogLevel.Warn:
        Sentry.captureMessage(line);
        break;
      case LogLevel.Error:
        error ? Sentry.captureException(error) : Sentry.captureException(line);
        break;
      default:
    }
  }
}
```