### PR TITLE
Set `cetLocktime` to current time

### DIFF
--- a/packages/core/lib/dlc/finance/Builder.ts
+++ b/packages/core/lib/dlc/finance/Builder.ts
@@ -168,7 +168,7 @@ export const buildOrderOffer = (
   orderOffer.offerCollateralSatoshis = totalCollateral - BigInt(premium);
   orderOffer.feeRatePerVb = BigInt(feePerByte);
 
-  orderOffer.cetLocktime = expiration;
+  orderOffer.cetLocktime = Math.floor(new Date().getTime() / 1000); // set to current time
   orderOffer.refundLocktime = expiration + 604800; // 1 week later
   return orderOffer;
 };


### PR DESCRIPTION
## What?
This PR sets the `cetLocktime` field in order offers to be the current time.

## Why?
The allow the execution of CETs once an oracle attestment is available. This is required for custom strategy oracles. 