### PR TITLE
Implement contractIds to dlcOffers query

### DIFF
--- a/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
@@ -125,6 +125,12 @@ describe('DlcAccept', () => {
         instance.type,
       );
     });
+
+    it('deserializes without cets', () => {
+      // Set parseCets to false
+      const dlcAccept = DlcAccept.deserialize(instance.serialize(), false);
+      expect(dlcAccept.cetSignatures.sigs.length).to.be.equal(0);
+    });
   });
 
   describe('DlcAcceptV0', () => {

--- a/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
@@ -140,6 +140,22 @@ describe('DlcAccept', () => {
           dlcAcceptHex.toString('hex'),
         );
       });
+
+      it('serializes a dlcAccept without cets', () => {
+        const _dlcAcceptWithoutSigs = DlcAccept.deserialize(
+          instance.serialize(),
+          false,
+        );
+        const dlcAcceptWithoutSigsHex = _dlcAcceptWithoutSigs
+          .serialize()
+          .toString('hex');
+        const dlcAcceptWithoutSigs = DlcAccept.deserialize(
+          Buffer.from(dlcAcceptWithoutSigsHex, 'hex'),
+          true,
+        );
+
+        expect(dlcAcceptWithoutSigs.cetSignatures.sigs.length).to.be.equal(0);
+      });
     });
 
     describe('deserialize', () => {

--- a/packages/messaging/lib/serialize/getTlv.ts
+++ b/packages/messaging/lib/serialize/getTlv.ts
@@ -1,5 +1,6 @@
 import { BufferReader, BufferWriter } from '@node-lightning/bufio';
 
+// TODO: add unit tests
 export function getTlv(reader: BufferReader): Buffer {
   const type = reader.readBigSize();
   const length = reader.readBigSize();

--- a/packages/messaging/lib/serialize/getTlv.ts
+++ b/packages/messaging/lib/serialize/getTlv.ts
@@ -12,3 +12,9 @@ export function getTlv(reader: BufferReader): Buffer {
 
   return writer.toBuffer();
 }
+
+export function skipTlv(reader: BufferReader): void {
+  reader.readBigSize();
+  const length = reader.readBigSize();
+  reader.readBytes(Number(length));
+}

--- a/packages/rocksdb/__tests__/rocksdb-dlc-store.spec.ts
+++ b/packages/rocksdb/__tests__/rocksdb-dlc-store.spec.ts
@@ -308,6 +308,25 @@ describe('RocksdbDlcStore', () => {
     });
   });
 
+  describe('find dlc_offer by contract_id', () => {
+    it('should return dlc offer object', async () => {
+      const tempContractIds = await sut.findTempContractIds([contractId]);
+      const dlcOffers = await sut.findDlcOffersByTempContractIds(
+        tempContractIds,
+      );
+
+      const actual = dlcOffers[0];
+
+      const actualFundingInputs = actual.fundingInputs as FundingInputV0[];
+      const expectedFundingInputs = dlcOffer.fundingInputs as FundingInputV0[];
+
+      expect(
+        actualFundingInputs[0].prevTx.serialize().toString('hex'),
+      ).to.equal(expectedFundingInputs[0].prevTx.serialize().toString('hex'));
+      expect(actual.contractInfo).to.deep.equal(dlcOffer.contractInfo);
+    });
+  });
+
   describe('find first dlc_accept', () => {
     it('should return dlc accept object', async () => {
       const actual = await sut.findFirstDlcAccept();


### PR DESCRIPTION
## What
Adds two functions to node-dlc

- Pass in a list of contractIds, and get tempContractIds
- Pass in a list of tempContractIds, and get an array of DlcOffers

Adds `parseCets` argument to `DlcAcceptV0.deserialize` to skip deserializing signatures

## Why
Enables efficient lookups of dlcOffers by contractIds