### PR TITLE
fix: remove `expiration` parameter

### DIFF
--- a/packages/core/__tests__/dlc/finance/Builder.spec.ts
+++ b/packages/core/__tests__/dlc/finance/Builder.spec.ts
@@ -28,7 +28,6 @@ describe('OrderOffer Builder', () => {
         strikePrice,
         premium,
         12,
-        157788000,
         10000,
         'bitcoin',
       );
@@ -44,7 +43,6 @@ describe('OrderOffer Builder', () => {
         totalCollateral,
         premium,
         12,
-        157788000,
         10000,
         'bitcoin',
       );
@@ -62,7 +60,6 @@ describe('OrderOffer Builder', () => {
         totalCollateral,
         premium,
         12,
-        157788000,
         10000,
         'bitcoin',
       );

--- a/packages/core/lib/dlc/finance/Builder.ts
+++ b/packages/core/lib/dlc/finance/Builder.ts
@@ -21,7 +21,6 @@ export const buildCoveredCallOrderOffer = (
   strikePrice: number,
   premium: number,
   feePerByte: number,
-  expiration: number,
   rounding: number,
   network: string,
 ): OrderOfferV0 => {
@@ -31,7 +30,6 @@ export const buildCoveredCallOrderOffer = (
     strikePrice,
     premium,
     feePerByte,
-    expiration,
     rounding,
     network,
     'call',
@@ -45,7 +43,6 @@ export const buildShortPutOrderOffer = (
   totalCollateral: number,
   premium: number,
   feePerByte: number,
-  expiration: number,
   rounding: number,
   network: string,
 ): OrderOfferV0 => {
@@ -55,7 +52,6 @@ export const buildShortPutOrderOffer = (
     strikePrice,
     premium,
     feePerByte,
-    expiration,
     rounding,
     network,
     'put',
@@ -84,7 +80,6 @@ export const buildOrderOffer = (
   strikePrice: number,
   premium: number,
   feePerByte: number,
-  expiration: number,
   rounding: number,
   network: string,
   type: 'call' | 'put',
@@ -169,6 +164,7 @@ export const buildOrderOffer = (
   orderOffer.feeRatePerVb = BigInt(feePerByte);
 
   orderOffer.cetLocktime = Math.floor(new Date().getTime() / 1000); // set to current time
-  orderOffer.refundLocktime = expiration + 604800; // 1 week later
+  orderOffer.refundLocktime =
+    announcement.oracleEvent.eventMaturityEpoch + 604800; // 1 week after maturity
   return orderOffer;
 };


### PR DESCRIPTION
## What

Remove `expiration` parameter from order offer builders

## Why

No longer needed. Base refund locktime off of `eventMaturityEpoch`