### PR TITLE
fix: switch primary and secondary servers

### DIFF
--- a/packages/transport/__tests__/irc/IrcManager.spec.ts
+++ b/packages/transport/__tests__/irc/IrcManager.spec.ts
@@ -6,6 +6,7 @@ import sinonChai from 'sinon-chai';
 
 import { ChannelType } from '../../lib/irc/ChannelType';
 import { IrcManager } from '../../lib/irc/IrcManager';
+import { IrcServers } from '../../lib/irc/Servers';
 import { createFakeLogger } from './helpers';
 
 chai.should();
@@ -22,14 +23,14 @@ describe('IrcManager', () => {
     sut = new IrcManager(
       createFakeLogger(),
       keyPair1.privateKey,
-      ['irc.darkscience.net'],
+      [IrcServers.primary_server.host],
       false,
       ChannelType.TestMarketPit,
     );
     bob = new IrcManager(
       createFakeLogger(),
       keyPair2.privateKey,
-      ['irc.darkscience.net'],
+      [IrcServers.primary_server.host],
       false,
       ChannelType.TestMarketPit,
     );

--- a/packages/transport/__tests__/irc/IrcOrderManager.spec.ts
+++ b/packages/transport/__tests__/irc/IrcOrderManager.spec.ts
@@ -7,6 +7,7 @@ import sinonChai from 'sinon-chai';
 
 import { ChannelType } from '../../lib/irc/ChannelType';
 import { IrcOrderManager } from '../../lib/irc/IrcOrderManager';
+import { IrcServers } from '../../lib/irc/Servers';
 import { createFakeLogger } from './helpers';
 
 chai.should();
@@ -38,14 +39,14 @@ describe('IrcOrderManager', () => {
     sut = new IrcOrderManager(
       createFakeLogger(),
       keyPair1.privateKey,
-      ['irc.darkscience.net'],
+      [IrcServers.primary_server.host],
       false,
       ChannelType.TestMarketPit,
     );
     bob = new IrcOrderManager(
       createFakeLogger(),
       keyPair2.privateKey,
-      ['irc.darkscience.net'],
+      [IrcServers.primary_server.host],
       false,
       ChannelType.TestMarketPit,
     );

--- a/packages/transport/lib/irc/Servers.ts
+++ b/packages/transport/lib/irc/Servers.ts
@@ -4,12 +4,12 @@ interface IrcServer {
 }
 
 const primary_server: IrcServer = {
-  host: 'irc.darkscience.net',
+  host: 'irc.hackint.org',
   port: 6697,
 };
 
 const secondary_server: IrcServer = {
-  host: 'irc.hackint.org',
+  host: 'irc.darkscience.net',
   port: 6697,
 };
 


### PR DESCRIPTION
## What

This PR switches primary and secondary servers (darkscience and hackint)

## Why

Darkscience has been having issues with `certificate has expired`. Should default to hackint until this is resolved

## Anything Else

Error logs on Dark Science

```
24 Mar 15:16:32 - Network error: Error: certificate has expired
24 Mar 15:16:32 - Connection got "close" event
24 Mar 15:16:32 - Disconnected: reconnecting
```