### PR TITLE
⬆️ upgrade: Update irc dependency

### DIFF
--- a/packages/transport/lib/irc/IrcManager.ts
+++ b/packages/transport/lib/irc/IrcManager.ts
@@ -3,7 +3,7 @@ import { Base58 } from '@node-lightning/bitcoin';
 import { sha256 } from '@node-lightning/crypto';
 import { ECPair } from 'bitcoinjs-lib';
 import { EventEmitter } from 'events';
-import irc from 'irc';
+import irc from 'irc-upd';
 import secp256k1 from 'secp256k1';
 
 import { ChannelType } from './ChannelType';

--- a/packages/transport/package-lock.json
+++ b/packages/transport/package-lock.json
@@ -4,20 +4,67 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@atomicfinance/bitcoin-networks": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@atomicfinance/bitcoin-networks/-/bitcoin-networks-2.5.0.tgz",
+			"integrity": "sha512-ZEdGKG1xsnWDCzNU7DkqWUSX51IrF+eQKiTKPcBKxYtwixxa9ED+iG0GYfKikKQn8u+7kVYLAO53Yikpa7XHsw==",
+			"requires": {
+				"@liquality/bitcoin-networks": "1.1.5",
+				"bitcoinjs-lib": "5.2.0"
+			},
+			"dependencies": {
+				"@liquality/bitcoin-networks": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.1.5.tgz",
+					"integrity": "sha512-CLnxerBZ+rTu/7zqbM6Z7P6RiUnfG71PPKvTCQtnc0v9G2QNwWvZYATNs8qUz3+iFV2co2PludDb452mm0iKqA==",
+					"requires": {
+						"@babel/runtime": "^7.12.1",
+						"@liquality/types": "^1.1.5",
+						"bitcoinjs-lib": "^5.2.0"
+					}
+				},
+				"@liquality/types": {
+					"version": "1.13.12",
+					"resolved": "https://registry.npmjs.org/@liquality/types/-/types-1.13.12.tgz",
+					"integrity": "sha512-42+ZfdmuZmGPDoYNJ7oCqR+3NtfLePBwtfpveoF2XQVu8FgzG/noH0/Nqz2Aw/TE1GD40n+ZrPRv6YDjDv+4xw==",
+					"requires": {
+						"bignumber.js": "^9.0.1"
+					}
+				}
+			}
+		},
 		"@babel/runtime": {
 			"version": "7.13.10",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
 			"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@liquality/bitcoin-networks": {
+			"version": "1.13.12",
+			"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.13.12.tgz",
+			"integrity": "sha512-jr1WJvmSQWc/cA/8nKP8vrmLLB/tlrY5ky+HZohCn8vnKT3Y/SQM18XeuT+2rdq4UcVfOQG00GXbS+4cAbKI0Q==",
+			"requires": {
+				"@babel/runtime": "^7.12.1",
+				"@liquality/types": "^1.13.12",
+				"bitcoinjs-lib": "^5.2.0"
+			},
+			"dependencies": {
+				"@liquality/types": {
+					"version": "1.13.12",
+					"resolved": "https://registry.npmjs.org/@liquality/types/-/types-1.13.12.tgz",
+					"integrity": "sha512-42+ZfdmuZmGPDoYNJ7oCqR+3NtfLePBwtfpveoF2XQVu8FgzG/noH0/Nqz2Aw/TE1GD40n+ZrPRv6YDjDv+4xw==",
+					"requires": {
+						"bignumber.js": "^9.0.1"
+					}
+				}
 			}
 		},
 		"@liquality/crypto": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/@liquality/crypto/-/crypto-1.0.0-beta.2.tgz",
 			"integrity": "sha512-5EerBozr9z69AEB98+eOec/IvAxEpKzO8Z8m4vw1te2MNAw5DPV64CL6vHOx4gaCYrJzHAboLmOuxXPnREu3Pg==",
-			"dev": true,
 			"requires": {
 				"bech32": "^1.1.3",
 				"bs58": "^4.0.1",
@@ -28,7 +75,6 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/@liquality/errors/-/errors-1.0.0-beta.2.tgz",
 			"integrity": "sha512-IfkzNHR2+8lm8BXSzwrGCkIDYyjYyKWpUOh30r8KOL2m5biz0RoYtApmwuxWTNn+/lxjUEzTSP0JLG41GjZJqQ==",
-			"dev": true,
 			"requires": {
 				"@types/standard-error": "^1.1.0",
 				"standard-error": "^1.1.0"
@@ -38,7 +84,6 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/@liquality/types/-/types-1.0.0-beta.2.tgz",
 			"integrity": "sha512-EPx9Gxm8eDl19pGCCAhNH2sHPws1xdVnRtTYNUCszakk+B1la6ZcoyFrW/bdhNGoALIgJtDiISZ1jl+LSpCFMw==",
-			"dev": true,
 			"requires": {
 				"bignumber.js": "^9.0.1"
 			}
@@ -47,13 +92,51 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/@liquality/utils/-/utils-1.0.0-beta.2.tgz",
 			"integrity": "sha512-AtzBNUvjJOx+t963eNO03VTGpx2NtHJTs3+ueI1T59ltHHvrJ93iWKUzBSONKkfEC2NvBk8uj+ww/s6/6BgVlw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.1",
 				"@liquality/crypto": "^1.0.0-beta.2",
 				"@liquality/errors": "^1.0.0-beta.2",
 				"@liquality/types": "^1.0.0-beta.2",
 				"setimmediate": "^1.0.5"
+			}
+		},
+		"@node-dlc/core": {
+			"version": "0.18.3",
+			"resolved": "https://registry.npmjs.org/@node-dlc/core/-/core-0.18.3.tgz",
+			"integrity": "sha512-9WbuP1UEjeoOeHDznS7Bp+nqvjMhOv4JmvUQYK35kQFNnBtkScAfzPH+GIQoya45Me0UwY/UL7udx19I/wvxOw==",
+			"requires": {
+				"@atomicfinance/bitcoin-networks": "^2.4.1",
+				"@liquality/bitcoin-networks": "^1.12.0",
+				"@node-dlc/messaging": "^0.18.3",
+				"@node-lightning/bitcoin": "0.26.1",
+				"@node-lightning/core": "0.26.1"
+			}
+		},
+		"@node-dlc/messaging": {
+			"version": "0.18.3",
+			"resolved": "https://registry.npmjs.org/@node-dlc/messaging/-/messaging-0.18.3.tgz",
+			"integrity": "sha512-QhyTMt6oReuJN3/rAIfp5b1X2pHQMKRZHBexsoncoZn9kjmwaz1jS+mk5RnMYIaG6Tlc51ypqAGdz0qz2+3FFQ==",
+			"requires": {
+				"@liquality/bitcoin-networks": "1.0.0-beta.2",
+				"@liquality/utils": "1.0.0-beta.2",
+				"@node-lightning/bitcoin": "0.26.1",
+				"@node-lightning/bufio": "0.26.1",
+				"@node-lightning/checksum": "0.26.1",
+				"@node-lightning/wire": "0.26.1",
+				"bip-schnorr": "0.6.3",
+				"bitcoinjs-lib": "5.2.0"
+			},
+			"dependencies": {
+				"@liquality/bitcoin-networks": {
+					"version": "1.0.0-beta.2",
+					"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.0.0-beta.2.tgz",
+					"integrity": "sha512-t40R9r8JlsDKtI7UF6IREVr51oK7K+UwHXAihLoZyWzi5uOQ6S5LKhs118GEN+81GDT7h7Wk/lEwgOMMaBDOgg==",
+					"requires": {
+						"@babel/runtime": "^7.12.1",
+						"@liquality/types": "^1.0.0-beta.2",
+						"bitcoinjs-lib": "^5.2.0"
+					}
+				}
 			}
 		},
 		"@node-lightning/bitcoin": {
@@ -164,8 +247,7 @@
 		"@types/standard-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@types/standard-error/-/standard-error-1.1.0.tgz",
-			"integrity": "sha512-lZshsx/QFLUJcu9prwm3Gtsl+b38HAqO6XUGH8PGwSmiswQhscd2MKrfk3LX3W3HyvNVUKcpsiuhU9r8DX32ww==",
-			"dev": true
+			"integrity": "sha512-lZshsx/QFLUJcu9prwm3Gtsl+b38HAqO6XUGH8PGwSmiswQhscd2MKrfk3LX3W3HyvNVUKcpsiuhU9r8DX32ww=="
 		},
 		"base-x": {
 			"version": "3.0.8",
@@ -180,11 +262,15 @@
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
+		"bigi": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
+			"integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
+		},
 		"bignumber.js": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-			"dev": true
+			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -192,6 +278,18 @@
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"requires": {
 				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"bip-schnorr": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/bip-schnorr/-/bip-schnorr-0.6.3.tgz",
+			"integrity": "sha512-aScZ6wkbhxki/WhVghCPUTT0Uwar9FJ0tpFPhj5LcyFhtuFDsLvb0uNvwEVAVMBe8pHdjfNMvylBjksPdorRhA==",
+			"requires": {
+				"bigi": "^1.4.2",
+				"ecurve": "^1.0.6",
+				"js-sha256": "^0.9.0",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.2.1"
 			}
 		},
 		"bip174": {
@@ -283,6 +381,12 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
+		"chardet": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-1.4.0.tgz",
+			"integrity": "sha512-NpwMDdSIprbYx1CLnfbxEIarI0Z+s9MssEgggMNheGM+WD68yOhV7IEA/3r6tr0yTRgQD0HuZJDw32s99i6L+A==",
+			"optional": true
+		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -321,7 +425,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-hashing/-/crypto-hashing-1.0.0.tgz",
 			"integrity": "sha1-MOFnNxkUMJVToevrHL5nU7DIjKo=",
-			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2"
 			}
@@ -331,6 +434,15 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
+		},
+		"ecurve": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
+			"integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
+			"requires": {
+				"bigi": "^1.1.0",
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -392,13 +504,13 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
-		"iconv": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/iconv/-/iconv-2.2.3.tgz",
-			"integrity": "sha1-4ITWDut9c9p/CpwJbkyKvgkL+u0=",
+		"iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 			"optional": true,
 			"requires": {
-				"nan": "^2.3.5"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
 		},
 		"inherits": {
@@ -406,20 +518,25 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"irc": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/irc/-/irc-0.5.2.tgz",
-			"integrity": "sha1-NxT0doNlqW0LL3dryRFmvrJGS7w=",
-			"requires": {
-				"iconv": "~2.2.1",
-				"irc-colors": "^1.1.0",
-				"node-icu-charset-detector": "~0.2.0"
-			}
-		},
 		"irc-colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
 			"integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
+		},
+		"irc-upd": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/irc-upd/-/irc-upd-0.11.0.tgz",
+			"integrity": "sha512-A1hV5cUkl5HZsKWRYcszD2Usfz33hB8igSSox8dEmrMyfy8/Ra6T/o4jwzs7jYMZ7ljLquSIWzcvSZHZ/bEAZA==",
+			"requires": {
+				"chardet": "^1.2.1",
+				"iconv-lite": "^0.6.2",
+				"irc-colors": "^1.5.0"
+			}
+		},
+		"js-sha256": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+			"integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
 		},
 		"just-extend": {
 			"version": "4.2.1",
@@ -509,15 +626,6 @@
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
 			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
-		"node-icu-charset-detector": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/node-icu-charset-detector/-/node-icu-charset-detector-0.2.0.tgz",
-			"integrity": "sha1-wjINo3Tdy2cfxUy0oOBB4Vb/1jk=",
-			"optional": true,
-			"requires": {
-				"nan": "^2.3.3"
-			}
-		},
 		"path": {
 			"version": "0.12.7",
 			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
@@ -563,8 +671,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.7",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-			"dev": true
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"ripemd160": {
 			"version": "2.0.2",
@@ -580,6 +687,12 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"optional": true
+		},
 		"secp256k1": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
@@ -593,8 +706,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -628,8 +740,7 @@
 		"standard-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/standard-error/-/standard-error-1.1.0.tgz",
-			"integrity": "sha1-I+UWj6HAggGJ5YEnAaeQWFENDTQ=",
-			"dev": true
+			"integrity": "sha1-I+UWj6HAggGJ5YEnAaeQWFENDTQ="
 		},
 		"string_decoder": {
 			"version": "1.3.0",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -31,7 +31,7 @@
     "@node-lightning/crypto": "0.26.1",
     "@node-lightning/wire": "0.26.1",
     "bitcoinjs-lib": "5.2.0",
-    "irc": "0.5.2",
+    "irc-upd": "^0.11.0",
     "secp256k1": "4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## What?

Upgrade irc dependency.

## Why?

To remove errors upon `yarn install` and also remove the need to build native libraries on local machines + CI. Significantly reduces building time.

This PR uses a forked version of `irc` which is more up to date and does not depend on native C libraries for compilation https://github.com/Throne3d/node-irc.

**Before:**

```bash
$ npm install

> iconv@2.2.3 install /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport/node_modules/iconv
> node-gyp rebuild

  CXX(target) Release/obj.target/iconv/src/binding.o
../src/binding.cc:35:11: error: no member named 'Handle' in namespace 'v8'
using v8::Handle;
      ~~~~^
../src/binding.cc:65:26: error: no template named 'Handle'
  static void Initialize(Handle<Object> obj)
                         ^
../src/binding.cc:71:60: error: too few arguments to function call, single argument 'context' was not specified
             Nan::New<FunctionTemplate>(Make)->GetFunction());
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:6482:46: note: 'GetFunction' declared here
  V8_WARN_UNUSED_RESULT MaybeLocal<Function> GetFunction(
                                             ^
../src/binding.cc:73:63: error: too few arguments to function call, single argument 'context' was not specified
             Nan::New<FunctionTemplate>(Convert)->GetFunction());
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:6482:46: note: 'GetFunction' declared here
  V8_WARN_UNUSED_RESULT MaybeLocal<Function> GetFunction(
                                             ^
../src/binding.cc:84:23: error: no matching constructor for initialization of 'String::Utf8Value'
    String::Utf8Value from_encoding(info[0]);
                      ^             ~~~~~~~
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3294:5: note: candidate constructor not viable: no known conversion from 'v8::Local<v8::Value>' to 'const v8::String::Utf8Value' for 1st argument
    Utf8Value(const Utf8Value&) = delete;
    ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3287:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    Utf8Value(Isolate* isolate, Local<v8::Value> obj);
    ^
../src/binding.cc:85:23: error: no matching constructor for initialization of 'String::Utf8Value'
    String::Utf8Value to_encoding(info[1]);
                      ^           ~~~~~~~
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3294:5: note: candidate constructor not viable: no known conversion from 'v8::Local<v8::Value>' to 'const v8::String::Utf8Value' for 1st argument
    Utf8Value(const Utf8Value&) = delete;
    ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3287:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    Utf8Value(Isolate* isolate, Local<v8::Value> obj);
    ^
../src/binding.cc:92:64: error: too few arguments to function call, single argument 'context' was not specified
        Nan::New<ObjectTemplate>(object_template)->NewInstance();
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:6762:44: note: 'NewInstance' declared here
  V8_WARN_UNUSED_RESULT MaybeLocal<Object> NewInstance(Local<Context> context);
                                           ^
../src/binding.cc:91:19: error: no viable conversion from 'MaybeLocal<v8::Object>' to 'Local<v8::Object>'
    Local<Object> obj =
                  ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:190:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'MaybeLocal<v8::Object>' to 'const v8::Local<v8::Object> &' for 1st argument
class Local {
      ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:190:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'MaybeLocal<v8::Object>' to 'v8::Local<v8::Object> &&' for 1st argument
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:194:13: note: candidate template ignored: could not match 'Local' against 'MaybeLocal'
  V8_INLINE Local(Local<S> that)
            ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:337:22: note: explicit constructor is not a candidate
  explicit V8_INLINE Local(T* that) : val_(that) {}
                     ^
../src/binding.cc:103:49: error: too few arguments to function call, single argument 'isolate' was not specified
    const bool is_flush = info[8]->BooleanValue();
                          ~~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:2858:8: note: 'BooleanValue' declared here
  bool BooleanValue(Isolate* isolate) const;
       ^
../src/binding.cc:106:47: error: too few arguments to function call, single argument 'context' was not specified
    size_t input_start = info[2]->Uint32Value();
                         ~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:2866:41: note: 'Uint32Value' declared here
  V8_WARN_UNUSED_RESULT Maybe<uint32_t> Uint32Value(
                                        ^
../src/binding.cc:106:12: error: no viable conversion from 'Maybe<uint32_t>' (aka 'Maybe<unsigned int>') to 'size_t' (aka 'unsigned long')
    size_t input_start = info[2]->Uint32Value();
           ^             ~~~~~~~~~~~~~~~~~~~~~~
../src/binding.cc:107:46: error: too few arguments to function call, single argument 'context' was not specified
    size_t input_size = info[3]->Uint32Value();
                        ~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:2866:41: note: 'Uint32Value' declared here
  V8_WARN_UNUSED_RESULT Maybe<uint32_t> Uint32Value(
                                        ^
../src/binding.cc:107:12: error: no viable conversion from 'Maybe<uint32_t>' (aka 'Maybe<unsigned int>') to 'size_t' (aka 'unsigned long')
    size_t input_size = info[3]->Uint32Value();
           ^            ~~~~~~~~~~~~~~~~~~~~~~
../src/binding.cc:109:48: error: too few arguments to function call, single argument 'context' was not specified
    size_t output_start = info[5]->Uint32Value();
                          ~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:2866:41: note: 'Uint32Value' declared here
  V8_WARN_UNUSED_RESULT Maybe<uint32_t> Uint32Value(
                                        ^
../src/binding.cc:109:12: error: no viable conversion from 'Maybe<uint32_t>' (aka 'Maybe<unsigned int>') to 'size_t' (aka 'unsigned long')
    size_t output_start = info[5]->Uint32Value();
           ^              ~~~~~~~~~~~~~~~~~~~~~~
../src/binding.cc:110:47: error: too few arguments to function call, single argument 'context' was not specified
    size_t output_size = info[6]->Uint32Value();
                         ~~~~~~~~~~~~~~~~~~~~ ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:2866:41: note: 'Uint32Value' declared here
  V8_WARN_UNUSED_RESULT Maybe<uint32_t> Uint32Value(
                                        ^
../src/binding.cc:110:12: error: no viable conversion from 'Maybe<uint32_t>' (aka 'Maybe<unsigned int>') to 'size_t' (aka 'unsigned long')
    size_t output_size = info[6]->Uint32Value();
           ^             ~~~~~~~~~~~~~~~~~~~~~~
../src/binding.cc:127:9: error: no matching member function for call to 'Set'
    rc->Set(0, Nan::New<Integer>(static_cast<uint32_t>(input_consumed)));
    ~~~~^~~
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3670:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
                                    ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3673:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
                                    ^
../src/binding.cc:128:9: error: no matching member function for call to 'Set'
    rc->Set(1, Nan::New<Integer>(static_cast<uint32_t>(output_consumed)));
    ~~~~^~~
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3670:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
                                    ^
/Users/dillionverma/Library/Caches/node-gyp/14.17.6/include/node/v8.h:3673:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
                                    ^
19 errors generated.
make: *** [Release/obj.target/iconv/src/binding.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/dillionverma/.nvm/versions/node/v14.17.6/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
gyp ERR! System Darwin 21.1.0
gyp ERR! command "/Users/dillionverma/.nvm/versions/node/v14.17.6/bin/node" "/Users/dillionverma/.nvm/versions/node/v14.17.6/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport/node_modules/iconv
gyp ERR! node -v v14.17.6
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok 

> node-icu-charset-detector@0.2.0 install /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport/node_modules/node-icu-charset-detector
> node-gyp rebuild

  CXX(target) Release/obj.target/node-icu-charset-detector/node-icu-charset-detector.o
../node-icu-charset-detector.cpp:7:10: fatal error: 'unicode/ucsdet.h' file not found
#include <unicode/ucsdet.h>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [Release/obj.target/node-icu-charset-detector/node-icu-charset-detector.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/dillionverma/.nvm/versions/node/v14.17.6/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
gyp ERR! System Darwin 21.1.0
gyp ERR! command "/Users/dillionverma/.nvm/versions/node/v14.17.6/bin/node" "/Users/dillionverma/.nvm/versions/node/v14.17.6/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport/node_modules/node-icu-charset-detector
gyp ERR! node -v v14.17.6
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok 
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> @node-dlc/transport@0.18.3 prepublish /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport
> npm run build


> @node-dlc/transport@0.18.3 build /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport
> ../../node_modules/.bin/tsc --project tsconfig.json

npm WARN sinon-chai@3.6.0 requires a peer of chai@^4.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: iconv@2.2.3 (node_modules/iconv):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: iconv@2.2.3 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: node-icu-charset-detector@0.2.0 (node_modules/node-icu-charset-detector):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: node-icu-charset-detector@0.2.0 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

added 1 package from 9 contributors, removed 4 packages and audited 109 packages in 9.929s

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

**After:**

```bash
$ npm install

npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> @node-dlc/transport@0.18.3 prepublish /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport
> npm run build


> @node-dlc/transport@0.18.3 build /Users/dillionverma/src/atomicfinance/node-dlc/packages/transport
> ../../node_modules/.bin/tsc --project tsconfig.json

npm WARN sinon-chai@3.6.0 requires a peer of chai@^4.0.0 but none is installed. You must install peer dependencies yourself.

added 9 packages from 4 contributors, updated 3 packages and audited 110 packages in 5.756s

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```