### PR TITLE
📦️  dep: switch to standalone `bitcoin-networks` pkg

### DIFF
--- a/packages/core/lib/dlc/finance/Builder.ts
+++ b/packages/core/lib/dlc/finance/Builder.ts
@@ -1,5 +1,3 @@
-import { chainHashFromNetwork } from '@atomicfinance/bitcoin-networks';
-import { BitcoinNetworks } from '@liquality/bitcoin-networks';
 import {
   ContractDescriptorV1,
   ContractInfoV0,
@@ -11,6 +9,7 @@ import {
   PayoutFunctionV0,
   RoundingIntervalsV0,
 } from '@node-dlc/messaging';
+import { BitcoinNetworks, chainHashFromNetwork } from 'bitcoin-networks';
 
 import { CoveredCall } from './CoveredCall';
 import { ShortPut } from './ShortPut';

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -4,53 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@atomicfinance/bitcoin-networks": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@atomicfinance/bitcoin-networks/-/bitcoin-networks-2.4.1.tgz",
-			"integrity": "sha512-Sq/AVUe7qVfgdFQFg6Ge86CH2bca3N/fSzY7+fdV0q21WALYhoxdUBBu0WA9PjTn7LGJet4sxtXM8+kJraAi+g==",
-			"requires": {
-				"@liquality/bitcoin-networks": "1.1.5",
-				"bitcoinjs-lib": "5.2.0"
-			},
-			"dependencies": {
-				"@liquality/bitcoin-networks": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.1.5.tgz",
-					"integrity": "sha512-CLnxerBZ+rTu/7zqbM6Z7P6RiUnfG71PPKvTCQtnc0v9G2QNwWvZYATNs8qUz3+iFV2co2PludDb452mm0iKqA==",
-					"requires": {
-						"@babel/runtime": "^7.12.1",
-						"@liquality/types": "^1.1.5",
-						"bitcoinjs-lib": "^5.2.0"
-					}
-				}
-			}
-		},
-		"@babel/runtime": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-			"integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-			"requires": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"@liquality/bitcoin-networks": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.12.0.tgz",
-			"integrity": "sha512-aOmScY4m3oU4EhPRiPZwnh5GrntvOzVfBkRz7bDte0+jET0gEiijsGCtMMd78ko29vwERimuFoiPjPjg3RS4Dw==",
-			"requires": {
-				"@babel/runtime": "^7.12.1",
-				"@liquality/types": "^1.12.0",
-				"bitcoinjs-lib": "^5.2.0"
-			}
-		},
-		"@liquality/types": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@liquality/types/-/types-1.12.0.tgz",
-			"integrity": "sha512-HS5ub0FilggJhd+rzubkLSUX30oOGvoxdPpcbO8O+lWIlt1MDh01hqFOgTEAv2fVL4e5dCYWcR/WYn0qBmC6Yw==",
-			"requires": {
-				"bignumber.js": "^9.0.1"
-			}
-		},
 		"@node-lightning/bitcoin": {
 			"version": "0.26.1",
 			"resolved": "https://registry.npmjs.org/@node-lightning/bitcoin/-/bitcoin-0.26.1.tgz",
@@ -102,11 +55,6 @@
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
-		"bignumber.js": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-			"integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -147,6 +95,14 @@
 			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
 			"requires": {
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bitcoin-networks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/bitcoin-networks/-/bitcoin-networks-1.0.0.tgz",
+			"integrity": "sha512-/SJGWp2ywQtBxoYT/l2IQUWmWIs8UA9s13iBNtGX+Nn8hZoPoZAXhfYY73LQ8C9MBzGLScPdMHqdsaHJPfrtIw==",
+			"requires": {
+				"bitcoinjs-lib": "5.2.0"
 			}
 		},
 		"bitcoin-ops": {
@@ -356,11 +312,6 @@
 				"string_decoder": "^1.1.1",
 				"util-deprecate": "^1.0.1"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
 		},
 		"ripemd160": {
 			"version": "2.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,11 +23,10 @@
     "url": "git+https://github.com/atomicfinance/node-dlc.git"
   },
   "dependencies": {
-    "@atomicfinance/bitcoin-networks": "^2.4.1",
-    "@liquality/bitcoin-networks": "^1.12.0",
     "@node-dlc/messaging": "^0.18.4",
     "@node-lightning/bitcoin": "0.26.1",
-    "@node-lightning/core": "0.26.1"
+    "@node-lightning/core": "0.26.1",
+    "bitcoin-networks": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.13"

--- a/packages/messaging/__tests__/messages/AddressCache.spec.ts
+++ b/packages/messaging/__tests__/messages/AddressCache.spec.ts
@@ -1,4 +1,4 @@
-import BitcoinNetworks from '@liquality/bitcoin-networks';
+import { BitcoinNetworks } from 'bitcoin-networks';
 import { expect } from 'chai';
 
 import { AddressCache, IAddressCache } from '../../lib/messages/AddressCache';

--- a/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
@@ -1,4 +1,4 @@
-import BitcoinNetworks from '@liquality/bitcoin-networks';
+import { BitcoinNetworks } from 'bitcoin-networks';
 import { expect } from 'chai';
 
 import { CetAdaptorSignaturesV0 } from '../../lib/messages/CetAdaptorSignaturesV0';

--- a/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
@@ -1,4 +1,4 @@
-import BitcoinNetworks from '@liquality/bitcoin-networks';
+import { BitcoinNetworks } from 'bitcoin-networks';
 import { expect } from 'chai';
 
 import { ContractInfo } from '../../lib/messages/ContractInfo';

--- a/packages/messaging/lib/messages/AddressCache.ts
+++ b/packages/messaging/lib/messages/AddressCache.ts
@@ -1,5 +1,5 @@
-import { BitcoinNetwork } from '@liquality/bitcoin-networks';
 import { BufferReader, BufferWriter } from '@node-lightning/bufio';
+import { BitcoinNetwork } from 'bitcoin-networks';
 import { address } from 'bitcoinjs-lib';
 
 import { MessageType } from '../MessageType';

--- a/packages/messaging/lib/messages/DlcAccept.ts
+++ b/packages/messaging/lib/messages/DlcAccept.ts
@@ -1,7 +1,7 @@
-import { BitcoinNetwork } from '@liquality/bitcoin-networks';
 import { Script } from '@node-lightning/bitcoin';
 import { BufferReader, BufferWriter } from '@node-lightning/bufio';
 import { hash160 } from '@node-lightning/crypto';
+import { BitcoinNetwork } from 'bitcoin-networks';
 import { address } from 'bitcoinjs-lib';
 import secp256k1 from 'secp256k1';
 

--- a/packages/messaging/lib/messages/DlcOffer.ts
+++ b/packages/messaging/lib/messages/DlcOffer.ts
@@ -1,7 +1,7 @@
-import { BitcoinNetwork } from '@liquality/bitcoin-networks';
 import { Script } from '@node-lightning/bitcoin';
 import { BufferReader, BufferWriter } from '@node-lightning/bufio';
 import { hash160 } from '@node-lightning/crypto';
+import { BitcoinNetwork } from 'bitcoin-networks';
 import { address } from 'bitcoinjs-lib';
 import secp256k1 from 'secp256k1';
 

--- a/packages/messaging/package-lock.json
+++ b/packages/messaging/package-lock.json
@@ -12,16 +12,6 @@
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
-		"@liquality/bitcoin-networks": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/@liquality/bitcoin-networks/-/bitcoin-networks-1.0.0-beta.2.tgz",
-			"integrity": "sha512-t40R9r8JlsDKtI7UF6IREVr51oK7K+UwHXAihLoZyWzi5uOQ6S5LKhs118GEN+81GDT7h7Wk/lEwgOMMaBDOgg==",
-			"requires": {
-				"@babel/runtime": "^7.12.1",
-				"@liquality/types": "^1.0.0-beta.2",
-				"bitcoinjs-lib": "^5.2.0"
-			}
-		},
 		"@liquality/crypto": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/@liquality/crypto/-/crypto-1.1.8.tgz",
@@ -255,6 +245,14 @@
 			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
 			"requires": {
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bitcoin-networks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/bitcoin-networks/-/bitcoin-networks-1.0.0.tgz",
+			"integrity": "sha512-/SJGWp2ywQtBxoYT/l2IQUWmWIs8UA9s13iBNtGX+Nn8hZoPoZAXhfYY73LQ8C9MBzGLScPdMHqdsaHJPfrtIw==",
+			"requires": {
+				"bitcoinjs-lib": "5.2.0"
 			}
 		},
 		"bitcoin-ops": {

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -22,14 +22,14 @@
     "url": "git+https://github.com/atomicfinance/node-dlc.git"
   },
   "dependencies": {
-    "@liquality/bitcoin-networks": "1.0.0-beta.2",
     "@liquality/utils": "1.0.0-beta.2",
     "@node-lightning/bitcoin": "0.26.1",
     "@node-lightning/bufio": "0.26.1",
     "@node-lightning/checksum": "0.26.1",
     "@node-lightning/wire": "0.26.1",
     "bip-schnorr": "0.6.3",
-    "bitcoinjs-lib": "5.2.0"
+    "bitcoinjs-lib": "5.2.0",
+    "bitcoin-networks": "^1.0.0"
   },
   "devDependencies": {
     "@node-lightning/logger": "0.26.1",


### PR DESCRIPTION
## What

Remove `@liquality/bitcoin-networks` and `@atomicfinance/bitcoin-networks` and use the new standalone package.

## Why

Remove cyclic dependency on `bitcoin-abstraction-layer`