### PR TITLE
🥅catch: non cso offer on decode

### DIFF
--- a/packages/core/__tests__/dlc/finance/CsoInfo.spec.ts
+++ b/packages/core/__tests__/dlc/finance/CsoInfo.spec.ts
@@ -122,6 +122,29 @@ describe('CsoInfo', () => {
         offerCollateral,
       });
     });
+
+    it('should throw if offerCollateralSatoshis does not match calculated offerCollateral', () => {
+      const { payoutFunction } = LinearPayout.buildPayoutFunction(
+        minPayout,
+        maxPayout,
+        startOutcome,
+        endOutcome,
+        oracleBase,
+        oracleDigits,
+      );
+
+      const dlcOffer = buildCsoDlcOfferFixture(
+        oracleDigits,
+        expiry,
+        payoutFunction,
+        maxPayout,
+        offerCollateralValue,
+      );
+
+      dlcOffer.offerCollateralSatoshis -= BigInt(10000);
+
+      expect(() => getCsoInfoFromOffer(dlcOffer)).to.throw(Error);
+    });
   });
 
   describe('validateCsoPayoutFunction', () => {

--- a/packages/core/lib/dlc/finance/CsoInfo.ts
+++ b/packages/core/lib/dlc/finance/CsoInfo.ts
@@ -11,7 +11,11 @@ import {
 import assert from 'assert';
 
 import { UNIT_MULTIPLIER } from './Builder';
-import { HasContractInfo, HasType } from './OptionInfo';
+import {
+  HasContractInfo,
+  HasOfferCollateralSatoshis,
+  HasType,
+} from './OptionInfo';
 
 export interface CsoInfo {
   maxLoss: Value;
@@ -100,7 +104,7 @@ export const getCsoInfoFromContractInfo = (
  * @returns {CsoInfo}
  */
 export const getCsoInfoFromOffer = (
-  offer: HasContractInfo & HasType,
+  offer: HasContractInfo & HasType & HasOfferCollateralSatoshis,
 ): CsoInfo => {
   if (
     offer.type !== MessageType.DlcOfferV0 &&
@@ -108,7 +112,12 @@ export const getCsoInfoFromOffer = (
   )
     throw Error('Only DlcOfferV0 and OrderOfferV0 currently supported');
 
-  return getCsoInfoFromContractInfo(offer.contractInfo);
+  const csoInfo = getCsoInfoFromContractInfo(offer.contractInfo);
+
+  if (csoInfo.offerCollateral.sats !== offer.offerCollateralSatoshis)
+    throw Error('Offer was not generated with CSO ContractInfo');
+
+  return csoInfo;
 };
 
 /**


### PR DESCRIPTION
## What

Throws if non-CSO offer is passed to `getCsoInfoFromOffer`

## Why

To ensure all offers were generated using `buildCustomStrategyOrderOffer`
