### PR TITLE
🐛 fix: funding inputs sorting DlcTxBuilder

### DIFF
--- a/packages/core/lib/dlc/TxBuilder.ts
+++ b/packages/core/lib/dlc/TxBuilder.ts
@@ -82,6 +82,10 @@ export class DlcTxBuilder {
       ...this.dlcAccept.fundingInputs,
     ];
 
+    fundingInputs.sort(
+      (a, b) => Number(a.inputSerialId) - Number(b.inputSerialId),
+    );
+
     fundingInputs.forEach((input) => {
       tx.addInput(
         OutPoint.fromString(


### PR DESCRIPTION
## What

Fix funding inputs sorting for `DlcTxBuilder`

## Why

Previously inputs were not being sorted by `inputSerialId`. This fix ensures that they follow the [DLC Spec protocol](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#funding_input). 

## Anything Else

C++ reference implementation: https://github.com/AtomicFinance/cfd-dlc/blob/develop/src/cfddlc_transactions.cpp#L188
