### PR TITLE
Add cso info to offers

### DIFF
--- a/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
@@ -1,6 +1,7 @@
 import { BitcoinNetworks } from 'bitcoin-networks';
 import { expect } from 'chai';
 
+import { OrderCsoInfoV0 } from '../../lib';
 import { ContractInfo } from '../../lib/messages/ContractInfo';
 import {
   DlcOffer,
@@ -158,6 +159,17 @@ describe('DlcOffer', () => {
           dlcOfferHex.toString('hex'),
         );
       });
+
+      it('serializes with csoinfo', () => {
+        const csoInfo = new OrderCsoInfoV0();
+        csoInfo.shiftForFees = 'acceptor';
+        csoInfo.fees = BigInt(1000);
+
+        instance.csoInfo = csoInfo;
+        expect(instance.serialize().toString('hex')).to.equal(
+          Buffer.concat([dlcOfferHex, csoInfo.serialize()]).toString('hex'),
+        );
+      });
     });
 
     describe('deserialize', () => {
@@ -188,6 +200,17 @@ describe('DlcOffer', () => {
         expect(DlcOfferV0.deserialize(dlcOfferHex).type).to.equal(
           MessageType.DlcOfferV0,
         );
+      });
+
+      it('deserializes with csoinfo', () => {
+        const csoInfo = new OrderCsoInfoV0();
+        csoInfo.shiftForFees = 'acceptor';
+        csoInfo.fees = BigInt(1000);
+
+        instance.csoInfo = csoInfo;
+        expect(
+          DlcOfferV0.deserialize(instance.serialize()).csoInfo.serialize(),
+        ).to.deep.equal(csoInfo.serialize());
       });
     });
 

--- a/packages/messaging/__tests__/messages/OrderOffer.spec.ts
+++ b/packages/messaging/__tests__/messages/OrderOffer.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { LOCKTIME_THRESHOLD, MessageType } from '../../lib';
+import { LOCKTIME_THRESHOLD, MessageType, OrderCsoInfoV0 } from '../../lib';
 import { ContractInfo } from '../../lib/messages/ContractInfo';
 import {
   IOrderIrcInfoJSON,
@@ -259,6 +259,59 @@ describe('OrderOffer', () => {
         "fdf536140b73747261746567792d383861815d8961815d89fdf5383210413046356b3448394335367867625246022d40fdc0db01b85bb4de6fe181c093b69c3a4558b7fc98a22e289b9d8da1d6f3" // order_irc_info_v0 tlv
       ); // prettier-ignore
     });
+
+    it('serializes with cso info', () => {
+      const csoInfo = new OrderCsoInfoV0();
+      csoInfo.shiftForFees = 'offeror';
+      csoInfo.fees = BigInt(10000);
+
+      instance.csoInfo = csoInfo;
+
+      expect(instance.serialize().toString('hex')).to.equal(
+        'f532' + // type
+          '06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f' + // chain_hash
+          'fdd82e' + // type contract_info
+          'fd0131' + // length
+          '000000000bebc200' + // total_collateral
+          'fda710' + // type contract_descriptor
+          '79' + // length
+          '03' + // num_outcomes
+          'c5a7affd51901bc7a51829b320d588dc7af0ad1f3d56f20a1d3c60c9ba7c6722' + // outcome_1
+          '0000000000000000' + // payout_1
+          'adf1c23fbeed6611efa5caa0e9ed4c440c450a18bc010a6c867e05873ac08ead' + // outcome_2
+          '00000000092363a3' + // payout_2
+          '6922250552ad6bb10ab3ddd6981b530aa9a6fd05725bf85b59e3e51163905288' + // outcome_3
+          '000000000bebc200' + // payout_3
+          'fda712' + // type oracle_info
+          'a8' + // length
+          'fdd824' + // type oracle_announcement
+          'a4' + // length
+          'fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9' + // announcement_signature_r
+          '494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4' + // announcement_signature_s
+          'da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0b' + // oracle_public_key
+          'fdd822' + // type oracle_event
+          '40' + // length
+          '0001' + // nb_nonces
+          '3cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b' + // oracle_nonces
+          '00000000' + // event_maturity_epoch
+          'fdd806' + // type enum_event_descriptor
+          '10' + // length
+          '0002' + // num_outcomes
+          '06' + // outcome_1_len
+          '64756d6d7931' + // outcome_1
+          '06' + // outcome_2_len
+          '64756d6d7932' + // outcome_2
+          '05' + // event_id_length
+          '64756d6d79' + // event_id
+          '0000000005f5e100' + // total_collateral_satoshis
+          '0000000000000001' + // fee_rate_per_vb
+          '00000064' + // cet_locktime
+          '000000c8' + // refund_locktime
+          'fdf536140b73747261746567792d383861815d8961815d89' +
+          'fdf5383210413046356b3448394335367867625246022d40fdc0db01b85bb4de6fe181c093b69c3a4558b7fc98a22e289b9d8da1d6f3' +
+          'fdf53a09010000000000002710', // order_irc_info_v0 tlv
+      );
+    });
   });
 
   describe('deserialize', () => {
@@ -318,6 +371,20 @@ describe('OrderOffer', () => {
       expect((instance.metadata as OrderMetadataV0).offerId).to.equal(
         'strategy-88',
       );
+    });
+
+    it('deserializes with csoinfo', () => {
+      const bufWithCsoInfo = Buffer.concat([
+        buf,
+        Buffer.from('fdf53a09010000000000002710', 'hex'),
+      ]);
+
+      const instance = OrderOfferV0.deserialize(bufWithCsoInfo);
+
+      expect((instance.csoInfo as OrderCsoInfoV0).shiftForFees).to.equal(
+        'offeror',
+      );
+      expect((instance.csoInfo as OrderCsoInfoV0).fees).to.equal(BigInt(10000));
     });
   });
 

--- a/packages/messaging/lib/MessageType.ts
+++ b/packages/messaging/lib/MessageType.ts
@@ -68,6 +68,7 @@ export enum MessageType {
   OrderAcceptV0 = 62772,
   OrderMetadataV0 = 62774,
   OrderIrcInfoV0 = 62776,
+  OrderCsoInfoV0 = 62778,
 
   OrderNegotiationFieldsV0 = 65334,
   OrderNegotiationFieldsV1 = 65336,

--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -31,6 +31,7 @@ export * from './messages/OracleInfoV0';
 export * from './messages/OrderAccept';
 export * from './messages/OrderNegotiationFields';
 export * from './messages/OrderOffer';
+export * from './messages/OrderCsoInfo';
 export * from './messages/OrderIrcInfo';
 export * from './messages/OrderMetadata';
 export * from './messages/PayoutCurvePiece';

--- a/packages/messaging/lib/messages/OrderCsoInfo.ts
+++ b/packages/messaging/lib/messages/OrderCsoInfo.ts
@@ -1,0 +1,112 @@
+import { BufferReader, BufferWriter } from '@node-lightning/bufio';
+
+import { MessageType } from '../MessageType';
+import { IDlcMessage } from './DlcMessage';
+
+export type DlcParty = 'offeror' | 'acceptor' | 'neither';
+
+export abstract class OrderCsoInfo {
+  public static deserialize(buf: Buffer): OrderCsoInfo {
+    const reader = new BufferReader(buf);
+
+    const type = Number(reader.readBigSize());
+
+    switch (type) {
+      case MessageType.OrderCsoInfoV0:
+        return OrderCsoInfoV0.deserialize(buf);
+      default:
+        throw new Error(`Order cso info TLV type must be OrderCsoInfoV0`);
+    }
+  }
+
+  public abstract type: number;
+
+  public abstract toJSON(): IOrderCsoInfoJSON;
+
+  public abstract serialize(): Buffer;
+}
+
+/**
+ * OrderCsoInfo message
+ */
+export class OrderCsoInfoV0 extends OrderCsoInfo implements IDlcMessage {
+  public static type = MessageType.OrderCsoInfoV0;
+
+  /**
+   * Deserializes an offer_dlc_v0 message
+   * @param buf
+   */
+  public static deserialize(buf: Buffer): OrderCsoInfoV0 {
+    const instance = new OrderCsoInfoV0();
+    const reader = new BufferReader(buf);
+
+    reader.readBigSize(); // read type
+    instance.length = reader.readBigSize();
+
+    const encodedShiftForFees = reader.readUInt8();
+    if (encodedShiftForFees === 0) {
+      instance.shiftForFees = 'neither';
+    } else if (encodedShiftForFees === 1) {
+      instance.shiftForFees = 'offeror';
+    } else if (encodedShiftForFees === 2) {
+      instance.shiftForFees = 'acceptor';
+    } else {
+      throw new Error(`Invalid shift for fees value: ${encodedShiftForFees}`);
+    }
+
+    instance.fees = reader.readUInt64BE();
+
+    return instance;
+  }
+
+  /**
+   * The type for order_metadata_v0 message. order_metadata_v0 = 62774
+   */
+  public type = OrderCsoInfoV0.type;
+
+  public length: bigint;
+
+  public shiftForFees: DlcParty = 'neither';
+
+  public fees = 0n;
+
+  /**
+   * Converts order_metadata_v0 to JSON
+   */
+  public toJSON(): IOrderCsoInfoJSON {
+    return {
+      type: this.type,
+      shiftForFees: this.shiftForFees,
+      fees: Number(this.fees),
+    };
+  }
+
+  /**
+   * Serializes the oracle_event message into a Buffer
+   */
+  public serialize(): Buffer {
+    const writer = new BufferWriter();
+    writer.writeBigSize(this.type);
+
+    const dataWriter = new BufferWriter();
+    dataWriter.writeUInt8(
+      this.shiftForFees === 'neither'
+        ? 0
+        : this.shiftForFees === 'offeror'
+        ? 1
+        : 2,
+    );
+    dataWriter.writeUInt64BE(this.fees);
+
+    writer.writeBigSize(dataWriter.size);
+    writer.writeBytes(dataWriter.toBuffer());
+
+    return writer.toBuffer();
+  }
+}
+
+export interface IOrderCsoInfoJSON {
+  type: number;
+  shiftForFees: string;
+  fees: number;
+}

--- a/packages/messaging/lib/messages/OrderIrcInfo.ts
+++ b/packages/messaging/lib/messages/OrderIrcInfo.ts
@@ -7,7 +7,7 @@ export abstract class OrderIrcInfo {
   public static deserialize(buf: Buffer): OrderIrcInfo {
     const reader = new BufferReader(buf);
 
-    const type = Number(reader.readUInt16BE());
+    const type = Number(reader.readBigSize());
 
     switch (type) {
       case MessageType.OrderIrcInfoV0:

--- a/packages/messaging/lib/messages/OrderMetadata.ts
+++ b/packages/messaging/lib/messages/OrderMetadata.ts
@@ -7,7 +7,7 @@ export abstract class OrderMetadata {
   public static deserialize(buf: Buffer): OrderMetadata {
     const reader = new BufferReader(buf);
 
-    const type = Number(reader.readUInt16BE());
+    const type = Number(reader.readBigSize());
 
     switch (type) {
       case MessageType.OrderMetadataV0:

--- a/packages/messaging/lib/messages/OrderOffer.ts
+++ b/packages/messaging/lib/messages/OrderOffer.ts
@@ -15,6 +15,7 @@ import {
   IContractInfoV1JSON,
 } from './ContractInfo';
 import { IDlcMessage } from './DlcMessage';
+import { IOrderCsoInfoJSON, OrderCsoInfo } from './OrderCsoInfo';
 import {
   IOrderIrcInfoJSON,
   OrderIrcInfo,
@@ -82,6 +83,9 @@ export class OrderOfferV0 extends OrderOffer implements IDlcMessage {
         case MessageType.OrderIrcInfoV0:
           instance.ircInfo = OrderIrcInfoV0.deserialize(buf);
           break;
+        case MessageType.OrderCsoInfoV0:
+          instance.csoInfo = OrderCsoInfo.deserialize(buf);
+          break;
         default:
           break;
       }
@@ -110,6 +114,8 @@ export class OrderOfferV0 extends OrderOffer implements IDlcMessage {
   public metadata?: OrderMetadata;
 
   public ircInfo?: OrderIrcInfo;
+
+  public csoInfo?: OrderCsoInfo;
 
   public validate(): void {
     validateBuffer(this.chainHash, 'chainHash', OrderOfferV0.name, 32);
@@ -178,6 +184,7 @@ export class OrderOfferV0 extends OrderOffer implements IDlcMessage {
 
     if (this.metadata) tlvs.push(this.metadata.toJSON());
     if (this.ircInfo) tlvs.push(this.ircInfo.toJSON());
+    if (this.csoInfo) tlvs.push(this.csoInfo.toJSON());
 
     return {
       type: this.type,
@@ -206,6 +213,7 @@ export class OrderOfferV0 extends OrderOffer implements IDlcMessage {
 
     if (this.metadata) writer.writeBytes(this.metadata.serialize());
     if (this.ircInfo) writer.writeBytes(this.ircInfo.serialize());
+    if (this.csoInfo) writer.writeBytes(this.csoInfo.serialize());
 
     return writer.toBuffer();
   }
@@ -219,5 +227,5 @@ export interface IOrderOfferJSON {
   feeRatePerVb: number;
   cetLocktime: number;
   refundLocktime: number;
-  tlvs: (IOrderMetadataJSON | IOrderIrcInfoJSON)[];
+  tlvs: (IOrderMetadataJSON | IOrderIrcInfoJSON | IOrderCsoInfoJSON)[];
 }


### PR DESCRIPTION
## What

This PR adds a new serializable TLV message OrderCsoInfo which contains `fees` and `shiftForFees` values.

It also adds TLV capability to DlcOffer messages (which is added anyway in https://github.com/discreetlogcontracts/dlcspecs/pull/163)

## Why

This is the first step to allow modification of the payout curve to allow for network fees to be shifted to the offeror or acceptor