### PR TITLE
🔊 log-add: error parsing msg irc mngr

### DIFF
--- a/packages/transport/lib/irc/IrcOrderManager.ts
+++ b/packages/transport/lib/irc/IrcOrderManager.ts
@@ -86,6 +86,7 @@ export class IrcOrderManager extends IrcManager {
           throw Error('DlcMessage type not supported');
       }
     } catch (e) {
+      this.logger.debug('error parsing message', e);
       this.emit('message', from, to, msg);
       this.logger.debug('message', from, to, msg);
     }


### PR DESCRIPTION
## What

Add logs when there's a failure to parse message in IrcOrderManager

## Why

Otherwise it's very difficult to debug when an invalid OrderOffer comes through