### PR TITLE
👽️ compat: improve env compability with bigint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,4 +19,27 @@ module.exports = {
     'prettier/prettier': 'error',
     'simple-import-sort/imports': 'error',
   },
+  overrides: [
+    {
+      // Apply this rule to all files
+      files: ['**/*'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'Literal[bigint]',
+            message:
+              'Avoid using bigint literals. Please use BigInt function notation instead. E.g., BigInt("123") instead of 123n.',
+          },
+        ],
+      },
+    },
+    {
+      // Exclude this rule for test files (*.test.js, *.test.ts, *.spec.js, *.spec.ts)
+      files: ['**/*.test.js', '**/*.test.ts', '**/*.spec.js', '**/*.spec.ts'],
+      rules: {
+        'no-restricted-syntax': 'off',
+      },
+    },
+  ],
 };

--- a/packages/messaging/lib/messages/OrderCsoInfo.ts
+++ b/packages/messaging/lib/messages/OrderCsoInfo.ts
@@ -68,7 +68,7 @@ export class OrderCsoInfoV0 extends OrderCsoInfo implements IDlcMessage {
 
   public shiftForFees: DlcParty = 'neither';
 
-  public fees = 0n;
+  public fees = BigInt(0);
 
   /**
    * Converts order_metadata_v0 to JSON


### PR DESCRIPTION
## What

bigint literals (`n` notation, i.e. 10n) isn't compatible with all environments

This PR switches bigint literals to `BigInt` function notation to improve env compatibility

## Anything Else

It also adds a new rule to eslintrc.js to ensure future bigint literals are caught