### PR TITLE
🐛 fix: division by zero cso builder bug

### DIFF
--- a/packages/core/__tests__/dlc/finance/Builder.spec.ts
+++ b/packages/core/__tests__/dlc/finance/Builder.spec.ts
@@ -273,6 +273,34 @@ describe('OrderOffer Builder', () => {
       expect(payoutCurvePieces[1].endpointPayout).to.equal(contractSize.sats);
     });
 
+    it('should build a CSO OrderOffer with contractSize 0', () => {
+      const contractSize = Value.zero();
+
+      const roundingIntervals = buildRoundingIntervalsFromIntervals(
+        contractSize,
+        [
+          { beginInterval: 0n, rounding: lowPrecisionRounding },
+          { beginInterval: 750000n, rounding: mediumPrecisionRounding },
+          { beginInterval: 850000n, rounding: highPrecisionRounding },
+          { beginInterval: 950000n, rounding: highestPrecisionRounding },
+        ],
+      );
+
+      const orderOffer = buildCustomStrategyOrderOffer(
+        oracleAnnouncement,
+        contractSize,
+        maxLoss,
+        maxGain,
+        feeRate,
+        roundingIntervals,
+        network,
+      );
+
+      expect(orderOffer.contractInfo.totalCollateral).to.equal(
+        contractSize.sats,
+      );
+    });
+
     it('should fail to build a CSO OrderOffer with an invalid oracleAnnouncement', () => {
       const contractSize = contractSizes[0];
 

--- a/packages/core/lib/dlc/finance/Builder.ts
+++ b/packages/core/lib/dlc/finance/Builder.ts
@@ -410,12 +410,15 @@ export const buildCustomStrategyOrderOffer = (
 
   const defaultContractSize = Value.fromBitcoin(1);
 
-  const shiftValue = Value.fromSats(
-    roundToNearestMultiplier(
-      (fees.sats * defaultContractSize.sats) / contractSize.sats,
-      UNIT_MULTIPLIER[unit.toLowerCase()],
-    ),
-  );
+  const shiftValue =
+    contractSize.sats > 0
+      ? Value.fromSats(
+          roundToNearestMultiplier(
+            (fees.sats * defaultContractSize.sats) / contractSize.sats,
+            UNIT_MULTIPLIER[unit.toLowerCase()],
+          ),
+        )
+      : Value.zero();
 
   if (shiftForFees === 'offeror') {
     startOutcomeValue.add(shiftValue);

--- a/packages/core/lib/dlc/finance/CsoInfo.ts
+++ b/packages/core/lib/dlc/finance/CsoInfo.ts
@@ -95,12 +95,15 @@ export const getCsoInfoFromContractInfo = (
   const contractSize = Value.fromSats(contractInfo.totalCollateral);
   const defaultContractSize = Value.fromBitcoin(1);
 
-  const shiftValue = Value.fromSats(
-    roundToNearestMultiplier(
-      (fees.sats * defaultContractSize.sats) / contractSize.sats,
-      UNIT_MULTIPLIER[unit.toLowerCase()],
-    ),
-  );
+  const shiftValue =
+    contractSize.sats > 0
+      ? Value.fromSats(
+          roundToNearestMultiplier(
+            (fees.sats * defaultContractSize.sats) / contractSize.sats,
+            UNIT_MULTIPLIER[unit.toLowerCase()],
+          ),
+        )
+      : Value.zero();
 
   if (shiftForFees === 'offeror') {
     startOutcomeValue.sub(shiftValue);


### PR DESCRIPTION
## What

Fix division by zero bug in cso builder and decoder

## Why

Even though an OrderOffer with zero contractSize is not considered valid, there are cases where you'd want a OrderOffer created with contractSize zero, such as offering liquidity