### PR TITLE
🐛 fix: switch to Value for option finance fns

### DIFF
--- a/packages/core/__tests__/dlc/finance/Builder.spec.ts
+++ b/packages/core/__tests__/dlc/finance/Builder.spec.ts
@@ -23,8 +23,9 @@ import {
 describe('OrderOffer Builder', () => {
   describe('buildCoveredCallOrderOffer', () => {
     const strikePrice = 50000;
-    const contractSize = 100000000;
-    const premium = 25000;
+    const contractSize = Value.fromSats(100000000);
+    const premium = Value.fromSats(25000);
+    const threeXPremium = Value.fromSats(75000);
     const totalCollateral = contractSize;
     const oracleAnnouncementBuf = Buffer.from(
       'fdd824fd02ab1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937eb8b005b07acf849ad2cec22107331dedbf5a607654fad4eafe39c278e27dde68fdd822fd02450011f9313f1edd903fab297d5350006b669506eb0ffda0bb58319b4df89ac24e14fd15f9791dc78d1596b06f4969bdb37d9e394dc9fedaa18d694027fa32b5ea2a5e60080c58e13727367c3a4ce1ad65dfb3c7e3ca1ea912b0299f6e383bab2875058aa96a1c74633130af6fbd008788de6ac9db76da4ecc7303383cc1a49f525316413850f7e3ac385019d560e84c5b3a3e9ae6c83f59fe4286ddfd23ea46d7ae04610a175cd28a9bf5f574e245c3dfe230dc4b0adf4daaea96780e594f6464f676505f4b74cfe3ffc33415a23de795bf939ce64c0c02033bbfc6c9ff26fb478943a1ece775f38f5db067ca4b2a9168b40792398def9164bfe5c46838472dc3c162af16c811b7a116e9417d5bccb9e5b8a5d7d26095aba993696188c3f85a02f7ab8d12ada171c352785eb63417228c7e248909fc2d673e1bb453140bf8bf429375819afb5e9556663b76ff09c2a7ba9779855ffddc6d360cb459cf8c42a2b949d0de19fe96163d336fd66a4ce2f1791110e679572a20036ffae50204ef520c01058ff4bef28218d1c0e362ee3694ad8b2ae83a51c86c4bc1630ed6202a158810096726f809fc828fafdcf053496affdf887ae8c54b6ca4323ccecf6a51121c4f0c60e790536dab41b221db1c6b35065dc19a9d31cf75901aa35eefecbb6fefd07296cda13cb34ce3b58eba20a0eb8f9614994ec7fee3cc290e30e6b1e3211ae1f3a85b6de6abdbb77d6d9ed33a1cee3bd5cd93a71f12c9c45e385d744ad0e7286660305100fdd80a11000200076274632f75736400000000001109425443205072696365',
@@ -71,7 +72,7 @@ describe('OrderOffer Builder', () => {
         oracleAnnouncement,
         contractSize,
         strikePrice,
-        premium * 3,
+        threeXPremium,
         premium,
         12,
         10000,
@@ -86,7 +87,7 @@ describe('OrderOffer Builder', () => {
         oracleAnnouncement,
         contractSize,
         strikePrice,
-        premium * 3,
+        threeXPremium,
         premium,
         12,
         10000,

--- a/packages/core/lib/dlc/finance/Builder.ts
+++ b/packages/core/lib/dlc/finance/Builder.ts
@@ -157,15 +157,15 @@ export const buildOrderOffer = (
  */
 export const buildOptionOrderOffer = (
   announcement: OracleAnnouncementV0,
-  contractSize: number,
+  contractSize: Value,
   strikePrice: number,
-  premium: number,
+  premium: Value,
   feePerByte: number | bigint,
   rounding: number,
   network: string,
   type: 'call' | 'put',
   direction: 'long' | 'short',
-  _totalCollateral?: number,
+  _totalCollateral?: Value,
 ): OrderOfferV0 => {
   const eventDescriptor = getDigitDecompositionEventDescriptor(announcement);
 
@@ -182,7 +182,7 @@ export const buildOptionOrderOffer = (
     if (type === 'call') {
       payoutFunctionInfo = CoveredCall.buildPayoutFunction(
         BigInt(strikePrice),
-        BigInt(contractSize),
+        contractSize.sats,
         eventDescriptor.base,
         eventDescriptor.nbDigits,
       );
@@ -201,12 +201,12 @@ export const buildOptionOrderOffer = (
     } else {
       payoutFunctionInfo = ShortPut.buildPayoutFunction(
         BigInt(strikePrice),
-        BigInt(contractSize),
-        BigInt(_totalCollateral),
+        contractSize.sats,
+        _totalCollateral.sats,
         eventDescriptor.base,
         eventDescriptor.nbDigits,
       );
-      totalCollateral = BigInt(_totalCollateral);
+      totalCollateral = _totalCollateral.sats;
       roundingIntervals.intervals = [
         {
           beginInterval: BigInt(0),
@@ -219,12 +219,12 @@ export const buildOptionOrderOffer = (
       ];
     }
   } else {
-    totalCollateral = BigInt(_totalCollateral);
+    totalCollateral = _totalCollateral.sats;
 
     if (type === 'call') {
       payoutFunctionInfo = LongCall.buildPayoutFunction(
         BigInt(strikePrice),
-        BigInt(contractSize),
+        contractSize.sats,
         totalCollateral,
         eventDescriptor.base,
         eventDescriptor.nbDigits,
@@ -243,7 +243,7 @@ export const buildOptionOrderOffer = (
     } else {
       payoutFunctionInfo = LongPut.buildPayoutFunction(
         BigInt(strikePrice),
-        BigInt(contractSize),
+        contractSize.sats,
         totalCollateral,
         eventDescriptor.base,
         eventDescriptor.nbDigits,
@@ -265,7 +265,7 @@ export const buildOptionOrderOffer = (
   const payoutFunction = payoutFunctionInfo.payoutFunction;
 
   const offerCollateral =
-    direction === 'short' ? totalCollateral - BigInt(premium) : BigInt(premium);
+    direction === 'short' ? totalCollateral - premium.sats : premium.sats;
 
   return buildOrderOffer(
     announcement,
@@ -292,9 +292,9 @@ export const buildOptionOrderOffer = (
  */
 export const buildCoveredCallOrderOffer = (
   announcement: OracleAnnouncementV0,
-  contractSize: number,
+  contractSize: Value,
   strikePrice: number,
-  premium: number,
+  premium: Value,
   feePerByte: number,
   rounding: number,
   network: string,
@@ -327,10 +327,10 @@ export const buildCoveredCallOrderOffer = (
  */
 export const buildShortPutOrderOffer = (
   announcement: OracleAnnouncementV0,
-  contractSize: number,
+  contractSize: Value,
   strikePrice: number,
-  totalCollateral: number,
-  premium: number,
+  totalCollateral: Value,
+  premium: Value,
   feePerByte: number,
   rounding: number,
   network: string,
@@ -364,10 +364,10 @@ export const buildShortPutOrderOffer = (
  */
 export const buildLongCallOrderOffer = (
   announcement: OracleAnnouncementV0,
-  contractSize: number,
+  contractSize: Value,
   strikePrice: number,
-  maxGain: number,
-  premium: number,
+  maxGain: Value,
+  premium: Value,
   feePerByte: number,
   rounding: number,
   network: string,
@@ -401,10 +401,10 @@ export const buildLongCallOrderOffer = (
  */
 export const buildLongPutOrderOffer = (
   announcement: OracleAnnouncementV0,
-  contractSize: number,
+  contractSize: Value,
   strikePrice: number,
-  maxGain: number,
-  premium: number,
+  maxGain: Value,
+  premium: Value,
   feePerByte: number,
   rounding: number,
   network: string,


### PR DESCRIPTION
## What

This PR switches to use `Value` for option finance functions

## Why

This makes development much more clear by making it clear what denomination is being used (sats or BTC)