### PR TITLE
feat: add dlc msg containers

### DIFF
--- a/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcAcceptV0.spec.ts
@@ -2,7 +2,11 @@ import { BitcoinNetworks } from 'bitcoin-networks';
 import { expect } from 'chai';
 
 import { CetAdaptorSignaturesV0 } from '../../lib/messages/CetAdaptorSignaturesV0';
-import { DlcAccept, DlcAcceptV0 } from '../../lib/messages/DlcAccept';
+import {
+  DlcAccept,
+  DlcAcceptContainer,
+  DlcAcceptV0,
+} from '../../lib/messages/DlcAccept';
 import { FundingInputV0 } from '../../lib/messages/FundingInput';
 import { NegotiationFields } from '../../lib/messages/NegotiationFields';
 import { MessageType } from '../../lib/MessageType';
@@ -114,7 +118,7 @@ describe('DlcAccept', () => {
 
   describe('deserialize', () => {
     it('should throw if incorrect type', () => {
-      instance.type = 0x123;
+      instance.type = 0x123 as MessageType;
       expect(function () {
         DlcAccept.deserialize(instance.serialize());
       }).to.throw(Error);
@@ -285,6 +289,24 @@ describe('DlcAccept', () => {
           instance.validate();
         }).to.throw(Error);
       });
+    });
+  });
+
+  describe('DlcAcceptContainer', () => {
+    it('should serialize and deserialize', () => {
+      const dlcAccept = DlcAcceptV0.deserialize(dlcAcceptHex);
+      // swap payout and change spk to differentiate between dlcaccepts
+      const dlcAccept2 = DlcAcceptV0.deserialize(dlcAcceptHex);
+      dlcAccept2.payoutSPK = dlcAccept.changeSPK;
+      dlcAccept2.changeSPK = dlcAccept.payoutSPK;
+
+      const container = new DlcAcceptContainer();
+      container.addAccept(dlcAccept);
+      container.addAccept(dlcAccept2);
+
+      const instance = DlcAcceptContainer.deserialize(container.serialize());
+
+      expect(container.serialize()).to.deep.equal(instance.serialize());
     });
   });
 });

--- a/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
+++ b/packages/messaging/__tests__/messages/DlcOfferV0.spec.ts
@@ -5,6 +5,7 @@ import { OrderPositionInfoV0 } from '../../lib';
 import { ContractInfo } from '../../lib/messages/ContractInfo';
 import {
   DlcOffer,
+  DlcOfferContainer,
   DlcOfferV0,
   LOCKTIME_THRESHOLD,
 } from '../../lib/messages/DlcOffer';
@@ -139,7 +140,7 @@ describe('DlcOffer', () => {
 
   describe('deserialize', () => {
     it('should throw if incorrect type', () => {
-      instance.type = 0x123;
+      instance.type = 0x123 as MessageType;
       expect(function () {
         DlcOffer.deserialize(instance.serialize());
       }).to.throw(Error);
@@ -409,6 +410,24 @@ describe('DlcOffer', () => {
           instance.validate();
         }).to.throw(Error);
       });
+    });
+  });
+
+  describe('DlcOfferContainer', () => {
+    it('should serialize and deserialize', () => {
+      const dlcOffer = DlcOfferV0.deserialize(dlcOfferHex);
+      // swap payout and change spk to differentiate between dlcoffers
+      const dlcOffer2 = DlcOfferV0.deserialize(dlcOfferHex);
+      dlcOffer2.payoutSPK = dlcOffer.changeSPK;
+      dlcOffer2.changeSPK = dlcOffer.payoutSPK;
+
+      const container = new DlcOfferContainer();
+      container.addOffer(dlcOffer);
+      container.addOffer(dlcOffer2);
+
+      const instance = DlcOfferContainer.deserialize(container.serialize());
+
+      expect(container.serialize()).to.deep.equal(instance.serialize());
     });
   });
 });

--- a/packages/messaging/__tests__/messages/OrderAccept.spec.ts
+++ b/packages/messaging/__tests__/messages/OrderAccept.spec.ts
@@ -1,11 +1,19 @@
 import { expect } from 'chai';
 
-import { OrderAcceptV0 } from '../../lib/messages/OrderAccept';
+import {
+  OrderAcceptContainer,
+  OrderAcceptV0,
+} from '../../lib/messages/OrderAccept';
 import { OrderNegotiationFieldsV0 } from '../../lib/messages/OrderNegotiationFields';
 
 describe('OrderAccept', () => {
   const tempOrderId = Buffer.from(
     '960fb5f7960382ac7e76f3e24eb6b00059b1e68632a946843c22e1f65fdf216a',
+    'hex',
+  );
+
+  const tempOrderId2 = Buffer.from(
+    '0ef55fca0e3d0a95609ddce833d2f8ba6c2ee37bbe8583bc2068256c51a32914',
     'hex',
   );
 
@@ -41,6 +49,29 @@ describe('OrderAccept', () => {
       expect(instance.negotiationFields.serialize().toString('hex')).to.equal(
         'fdff3600',
       );
+    });
+  });
+
+  describe('OrderAcceptContainer', () => {
+    it('should serialize and deserialize', () => {
+      const orderAccept = new OrderAcceptV0();
+
+      orderAccept.tempOrderId = tempOrderId;
+      orderAccept.negotiationFields = OrderNegotiationFieldsV0.deserialize(
+        Buffer.from('fdff3600', 'hex'),
+      );
+
+      // swap payout and change spk to differentiate between dlcoffers
+      const orderAccept2 = OrderAcceptV0.deserialize(orderAccept.serialize());
+      orderAccept2.tempOrderId = tempOrderId2;
+
+      const container = new OrderAcceptContainer();
+      container.addAccept(orderAccept);
+      container.addAccept(orderAccept2);
+
+      const instance = OrderAcceptContainer.deserialize(container.serialize());
+
+      expect(container.serialize()).to.deep.equal(instance.serialize());
     });
   });
 });

--- a/packages/messaging/__tests__/messages/OrderOffer.spec.ts
+++ b/packages/messaging/__tests__/messages/OrderOffer.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   LOCKTIME_THRESHOLD,
   MessageType,
+  OrderOfferContainer,
   OrderPositionInfoV0,
 } from '../../lib';
 import { ContractInfo } from '../../lib/messages/ContractInfo';
@@ -524,6 +525,23 @@ describe('OrderOffer', () => {
       expect(function () {
         instance.validate();
       }).to.throw(Error);
+    });
+  });
+
+  describe('OrderOfferContainer', () => {
+    it('should serialize and deserialize', () => {
+      const orderOffer = OrderOfferV0.deserialize(buf);
+      // swap payout and change spk to differentiate between dlcoffers
+      const orderOffer2 = OrderOfferV0.deserialize(buf);
+      orderOffer2.refundLocktime = 300;
+
+      const container = new OrderOfferContainer();
+      container.addOffer(orderOffer);
+      container.addOffer(orderOffer2);
+
+      const instance = OrderOfferContainer.deserialize(container.serialize());
+
+      expect(container.serialize()).to.deep.equal(instance.serialize());
     });
   });
 });

--- a/packages/messaging/lib/messages/DlcOffer.ts
+++ b/packages/messaging/lib/messages/DlcOffer.ts
@@ -397,3 +397,60 @@ export interface IDlcOfferV0Addresses {
   changeAddress: string;
   payoutAddress: string;
 }
+
+export class DlcOfferContainer {
+  private offers: DlcOffer[] = [];
+
+  /**
+   * Adds a DlcOffer to the container.
+   * @param offer The DlcOffer to add.
+   */
+  public addOffer(offer: DlcOffer): void {
+    this.offers.push(offer);
+  }
+
+  /**
+   * Returns all DlcOffers in the container.
+   * @returns An array of DlcOffer instances.
+   */
+  public getOffers(): DlcOffer[] {
+    return this.offers;
+  }
+
+  /**
+   * Serializes all DlcOffers in the container to a Buffer.
+   * @returns A Buffer containing the serialized DlcOffers.
+   */
+  public serialize(): Buffer {
+    const writer = new BufferWriter();
+    // Write the number of offers in the container first.
+    writer.writeUInt16BE(this.offers.length);
+    // Serialize each offer and write it.
+    this.offers.forEach((offer) => {
+      const serializedOffer = offer.serialize();
+      // Optionally, write the length of the serialized offer for easier deserialization.
+      writer.writeUInt16BE(serializedOffer.length);
+      writer.writeBytes(serializedOffer);
+    });
+    return writer.toBuffer();
+  }
+
+  /**
+   * Deserializes a Buffer into a DlcOfferContainer with DlcOffers.
+   * @param buf The Buffer to deserialize.
+   * @returns A DlcOfferContainer instance.
+   */
+  public static deserialize(buf: Buffer): DlcOfferContainer {
+    const reader = new BufferReader(buf);
+    const container = new DlcOfferContainer();
+    const offersCount = reader.readUInt16BE();
+    for (let i = 0; i < offersCount; i++) {
+      // Optionally, read the length of the serialized offer if it was written during serialization.
+      const offerLength = reader.readUInt16BE();
+      const offerBuf = reader.readBytes(offerLength);
+      const offer = DlcOffer.deserialize(offerBuf); // This needs to be adjusted based on actual implementation.
+      container.addOffer(offer);
+    }
+    return container;
+  }
+}

--- a/packages/messaging/lib/messages/OrderAccept.ts
+++ b/packages/messaging/lib/messages/OrderAccept.ts
@@ -95,3 +95,58 @@ export interface IOrderAcceptV0JSON {
     | IOrderNegotiationFieldsV0JSON
     | IOrderNegotiationFieldsV1JSON;
 }
+
+export class OrderAcceptContainer {
+  private accepts: OrderAccept[] = [];
+
+  /**
+   * Adds an OrderAccept to the container.
+   * @param accept The OrderAccept to add.
+   */
+  public addAccept(accept: OrderAccept): void {
+    this.accepts.push(accept);
+  }
+
+  /**
+   * Returns all OrderAccepts in the container.
+   * @returns An array of OrderAccept instances.
+   */
+  public getAccepts(): OrderAccept[] {
+    return this.accepts;
+  }
+
+  /**
+   * Serializes all OrderAccepts in the container to a Buffer.
+   * @returns A Buffer containing the serialized OrderAccepts.
+   */
+  public serialize(): Buffer {
+    const writer = new BufferWriter();
+    // Write the number of accepts in the container first.
+    writer.writeUInt16BE(this.accepts.length);
+    // Serialize each accept and write it.
+    this.accepts.forEach((accept) => {
+      const serializedAccept = accept.serialize();
+      writer.writeUInt16BE(serializedAccept.length);
+      writer.writeBytes(serializedAccept);
+    });
+    return writer.toBuffer();
+  }
+
+  /**
+   * Deserializes a Buffer into an OrderAcceptContainer with OrderAccepts.
+   * @param buf The Buffer to deserialize.
+   * @returns An OrderAcceptContainer instance.
+   */
+  public static deserialize(buf: Buffer): OrderAcceptContainer {
+    const reader = new BufferReader(buf);
+    const container = new OrderAcceptContainer();
+    const acceptsCount = reader.readUInt16BE();
+    for (let i = 0; i < acceptsCount; i++) {
+      const acceptLength = reader.readUInt16BE();
+      const acceptBuf = reader.readBytes(acceptLength);
+      const accept = OrderAccept.deserialize(acceptBuf); // Adjust based on actual implementation.
+      container.addAccept(accept);
+    }
+    return container;
+  }
+}

--- a/packages/messaging/lib/messages/OrderOffer.ts
+++ b/packages/messaging/lib/messages/OrderOffer.ts
@@ -251,3 +251,60 @@ export interface IOrderOfferJSON {
     | IBatchFundingGroupJSON
   )[];
 }
+
+export class OrderOfferContainer {
+  private offers: OrderOffer[] = [];
+
+  /**
+   * Adds an OrderOffer to the container.
+   * @param offer The OrderOffer to add.
+   */
+  public addOffer(offer: OrderOffer): void {
+    this.offers.push(offer);
+  }
+
+  /**
+   * Returns all OrderOffers in the container.
+   * @returns An array of OrderOffer instances.
+   */
+  public getOffers(): OrderOffer[] {
+    return this.offers;
+  }
+
+  /**
+   * Serializes all OrderOffers in the container to a Buffer.
+   * @returns A Buffer containing the serialized OrderOffers.
+   */
+  public serialize(): Buffer {
+    const writer = new BufferWriter();
+    // Write the number of offers in the container first.
+    writer.writeUInt16BE(this.offers.length);
+    // Serialize each offer and write it.
+    this.offers.forEach((offer) => {
+      const serializedOffer = offer.serialize();
+      // Optionally, write the length of the serialized offer for easier deserialization.
+      writer.writeUInt16BE(serializedOffer.length);
+      writer.writeBytes(serializedOffer);
+    });
+    return writer.toBuffer();
+  }
+
+  /**
+   * Deserializes a Buffer into an OrderOfferContainer with OrderOffers.
+   * @param buf The Buffer to deserialize.
+   * @returns An OrderOfferContainer instance.
+   */
+  public static deserialize(buf: Buffer): OrderOfferContainer {
+    const reader = new BufferReader(buf);
+    const container = new OrderOfferContainer();
+    const offersCount = reader.readUInt16BE();
+    for (let i = 0; i < offersCount; i++) {
+      // Optionally, read the length of the serialized offer if it was written during serialization.
+      const offerLength = reader.readUInt16BE();
+      const offerBuf = reader.readBytes(offerLength);
+      const offer = OrderOffer.deserialize(offerBuf); // Adjust based on actual implementation.
+      container.addOffer(offer);
+    }
+    return container;
+  }
+}


### PR DESCRIPTION
## What

Add DLC message containers

## Why

Useful for broadcasting internally over ZMQ and for batch funding DLC transactions