### PR TITLE
fix: switch dlc message container to bigsize

### DIFF
--- a/packages/messaging/lib/messages/DlcAccept.ts
+++ b/packages/messaging/lib/messages/DlcAccept.ts
@@ -357,12 +357,12 @@ export class DlcAcceptContainer {
   public serialize(): Buffer {
     const writer = new BufferWriter();
     // Write the number of accepts in the container first.
-    writer.writeUInt16BE(this.accepts.length);
+    writer.writeBigSize(this.accepts.length);
     // Serialize each accept and write it.
     this.accepts.forEach((accept) => {
       const serializedAccept = accept.serialize();
       // Optionally, write the length of the serialized accept for easier deserialization.
-      writer.writeUInt16BE(serializedAccept.length);
+      writer.writeBigSize(serializedAccept.length);
       writer.writeBytes(serializedAccept);
     });
     return writer.toBuffer();
@@ -376,10 +376,10 @@ export class DlcAcceptContainer {
   public static deserialize(buf: Buffer, parseCets = true): DlcAcceptContainer {
     const reader = new BufferReader(buf);
     const container = new DlcAcceptContainer();
-    const acceptsCount = reader.readUInt16BE();
+    const acceptsCount = reader.readBigSize();
     for (let i = 0; i < acceptsCount; i++) {
-      const acceptLength = reader.readUInt16BE();
-      const acceptBuf = reader.readBytes(acceptLength);
+      const acceptLength = reader.readBigSize();
+      const acceptBuf = reader.readBytes(Number(acceptLength));
       const accept = DlcAccept.deserialize(acceptBuf, parseCets); // Adjust based on actual implementation.
       container.addAccept(accept);
     }

--- a/packages/messaging/lib/messages/DlcOffer.ts
+++ b/packages/messaging/lib/messages/DlcOffer.ts
@@ -424,12 +424,12 @@ export class DlcOfferContainer {
   public serialize(): Buffer {
     const writer = new BufferWriter();
     // Write the number of offers in the container first.
-    writer.writeUInt16BE(this.offers.length);
+    writer.writeBigSize(this.offers.length);
     // Serialize each offer and write it.
     this.offers.forEach((offer) => {
       const serializedOffer = offer.serialize();
       // Optionally, write the length of the serialized offer for easier deserialization.
-      writer.writeUInt16BE(serializedOffer.length);
+      writer.writeBigSize(serializedOffer.length);
       writer.writeBytes(serializedOffer);
     });
     return writer.toBuffer();
@@ -443,11 +443,11 @@ export class DlcOfferContainer {
   public static deserialize(buf: Buffer): DlcOfferContainer {
     const reader = new BufferReader(buf);
     const container = new DlcOfferContainer();
-    const offersCount = reader.readUInt16BE();
+    const offersCount = reader.readBigSize();
     for (let i = 0; i < offersCount; i++) {
       // Optionally, read the length of the serialized offer if it was written during serialization.
-      const offerLength = reader.readUInt16BE();
-      const offerBuf = reader.readBytes(offerLength);
+      const offerLength = reader.readBigSize();
+      const offerBuf = reader.readBytes(Number(offerLength));
       const offer = DlcOffer.deserialize(offerBuf); // This needs to be adjusted based on actual implementation.
       container.addOffer(offer);
     }

--- a/packages/messaging/lib/messages/DlcSign.ts
+++ b/packages/messaging/lib/messages/DlcSign.ts
@@ -135,12 +135,12 @@ export class DlcSignContainer {
   public serialize(): Buffer {
     const writer = new BufferWriter();
     // Write the number of signs in the container first.
-    writer.writeUInt16BE(this.signs.length);
+    writer.writeBigSize(this.signs.length);
     // Serialize each sign and write it.
     this.signs.forEach((sign) => {
       const serializedSign = sign.serialize();
       // Optionally, write the length of the serialized sign for easier deserialization.
-      writer.writeUInt16BE(serializedSign.length);
+      writer.writeBigSize(serializedSign.length);
       writer.writeBytes(serializedSign);
     });
     return writer.toBuffer();
@@ -154,11 +154,11 @@ export class DlcSignContainer {
   public static deserialize(buf: Buffer): DlcSignContainer {
     const reader = new BufferReader(buf);
     const container = new DlcSignContainer();
-    const signsCount = reader.readUInt16BE();
+    const signsCount = reader.readBigSize();
     for (let i = 0; i < signsCount; i++) {
       // Optionally, read the length of the serialized sign if it was written during serialization.
-      const signLength = reader.readUInt16BE();
-      const signBuf = reader.readBytes(signLength);
+      const signLength = reader.readBigSize();
+      const signBuf = reader.readBytes(Number(signLength));
       const sign = DlcSign.deserialize(signBuf); // Adjust based on actual implementation.
       container.addSign(sign);
     }

--- a/packages/messaging/lib/messages/OrderAccept.ts
+++ b/packages/messaging/lib/messages/OrderAccept.ts
@@ -122,11 +122,11 @@ export class OrderAcceptContainer {
   public serialize(): Buffer {
     const writer = new BufferWriter();
     // Write the number of accepts in the container first.
-    writer.writeUInt16BE(this.accepts.length);
+    writer.writeBigSize(this.accepts.length);
     // Serialize each accept and write it.
     this.accepts.forEach((accept) => {
       const serializedAccept = accept.serialize();
-      writer.writeUInt16BE(serializedAccept.length);
+      writer.writeBigSize(serializedAccept.length);
       writer.writeBytes(serializedAccept);
     });
     return writer.toBuffer();
@@ -140,10 +140,10 @@ export class OrderAcceptContainer {
   public static deserialize(buf: Buffer): OrderAcceptContainer {
     const reader = new BufferReader(buf);
     const container = new OrderAcceptContainer();
-    const acceptsCount = reader.readUInt16BE();
+    const acceptsCount = reader.readBigSize();
     for (let i = 0; i < acceptsCount; i++) {
-      const acceptLength = reader.readUInt16BE();
-      const acceptBuf = reader.readBytes(acceptLength);
+      const acceptLength = reader.readBigSize();
+      const acceptBuf = reader.readBytes(Number(acceptLength));
       const accept = OrderAccept.deserialize(acceptBuf); // Adjust based on actual implementation.
       container.addAccept(accept);
     }

--- a/packages/messaging/lib/messages/OrderOffer.ts
+++ b/packages/messaging/lib/messages/OrderOffer.ts
@@ -278,12 +278,12 @@ export class OrderOfferContainer {
   public serialize(): Buffer {
     const writer = new BufferWriter();
     // Write the number of offers in the container first.
-    writer.writeUInt16BE(this.offers.length);
+    writer.writeBigSize(this.offers.length);
     // Serialize each offer and write it.
     this.offers.forEach((offer) => {
       const serializedOffer = offer.serialize();
       // Optionally, write the length of the serialized offer for easier deserialization.
-      writer.writeUInt16BE(serializedOffer.length);
+      writer.writeBigSize(serializedOffer.length);
       writer.writeBytes(serializedOffer);
     });
     return writer.toBuffer();
@@ -297,11 +297,11 @@ export class OrderOfferContainer {
   public static deserialize(buf: Buffer): OrderOfferContainer {
     const reader = new BufferReader(buf);
     const container = new OrderOfferContainer();
-    const offersCount = reader.readUInt16BE();
+    const offersCount = reader.readBigSize();
     for (let i = 0; i < offersCount; i++) {
       // Optionally, read the length of the serialized offer if it was written during serialization.
-      const offerLength = reader.readUInt16BE();
-      const offerBuf = reader.readBytes(offerLength);
+      const offerLength = reader.readBigSize();
+      const offerBuf = reader.readBytes(Number(offerLength));
       const offer = OrderOffer.deserialize(offerBuf); // Adjust based on actual implementation.
       container.addOffer(offer);
     }


### PR DESCRIPTION
## What

Switch DlcMessage containers to use BigSize for num length and serialized length

## Why

Prevent size of accept and sign messages causing out-of-range error